### PR TITLE
fix: assorted backend/UI bugfixes (Xtream parsing, CSP, SQLite prune, profile rename)

### DIFF
--- a/src-tauri/src/db/mutations.rs
+++ b/src-tauri/src/db/mutations.rs
@@ -278,25 +278,30 @@ pub fn merge_channels(
                 params![playlist_id],
             )?;
         } else {
-            let ids_to_keep: Vec<i64> = matched_ids.into_iter().collect();
-            let placeholders: String = (0..ids_to_keep.len())
-                .map(|i| format!("?{}", i + 2))
-                .collect::<Vec<_>>()
-                .join(",");
-            let sql = format!(
-                "DELETE FROM channels WHERE playlist_id = ?1 AND id NOT IN ({})",
-                placeholders
-            );
+            // A `NOT IN (?, ?, ..., ?)` with one bound param per row blows past
+            // SQLite's expression-depth limit (SQLITE_MAX_EXPR_DEPTH, default 1000)
+            // for large playlists. Stage the ids to keep in a temp table instead,
+            // so the DELETE only ever references a single subquery.
+            tx.execute_batch(
+                "CREATE TEMP TABLE IF NOT EXISTS channels_to_keep (id INTEGER PRIMARY KEY);
+                 DELETE FROM channels_to_keep;",
+            )?;
 
-            let mut delete_params: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
-            delete_params.push(Box::new(playlist_id));
-            for id in &ids_to_keep {
-                delete_params.push(Box::new(*id));
+            {
+                let mut keep_stmt =
+                    tx.prepare_cached("INSERT INTO channels_to_keep (id) VALUES (?1)")?;
+                for id in &matched_ids {
+                    keep_stmt.execute(params![id])?;
+                }
             }
-            let param_refs: Vec<&dyn rusqlite::types::ToSql> =
-                delete_params.iter().map(|p| p.as_ref()).collect();
 
-            tx.execute(&sql, param_refs.as_slice())?;
+            tx.execute(
+                "DELETE FROM channels WHERE playlist_id = ?1
+                 AND id NOT IN (SELECT id FROM channels_to_keep)",
+                params![playlist_id],
+            )?;
+
+            tx.execute_batch("DELETE FROM channels_to_keep;")?;
         }
     }
 
@@ -457,6 +462,51 @@ mod tests {
 
         let stored = get_channels(&conn, Some(playlist_id)).unwrap();
         assert_eq!(stored.len(), 100);
+    }
+
+    /// Regression test: a `NOT IN` clause built with one bound parameter per row
+    /// used to blow past SQLite's expression-depth limit (default 1000) on large
+    /// playlists, surfacing a raw SQL error to the user during refresh.
+    #[test]
+    fn test_merge_channels_deletes_stale_rows_in_large_playlist() {
+        let conn = setup_test_db();
+        let playlist_id = create_test_playlist(&conn, "Large Playlist");
+
+        const KEEP_COUNT: i32 = 1500;
+        let existing: Vec<Channel> = (0..KEEP_COUNT + 1)
+            .map(|i| Channel {
+                id: None,
+                playlist_id,
+                name: format!("Channel {}", i),
+                url: format!("http://example.com/stream{}.m3u8", i),
+                logo: None,
+                group_name: Some("Large Group".to_string()),
+                epg_id: None,
+                tvg_name: None,
+                content_type: "live".to_string(),
+                is_favorite: false,
+                sort_order: i,
+                category_order: 0,
+                created_at: None,
+            })
+            .collect();
+        create_channels_batch(&conn, &existing).unwrap();
+        assert_eq!(
+            get_channels(&conn, Some(playlist_id)).unwrap().len(),
+            (KEEP_COUNT + 1) as usize
+        );
+
+        // Refresh matches all but one channel (by name+group_name), so it must
+        // delete exactly one stale row out of a `keep` set of 1500.
+        let refreshed: Vec<Channel> = existing[..KEEP_COUNT as usize].to_vec();
+        let result = merge_channels(&conn, playlist_id, &refreshed, false).unwrap();
+
+        assert_eq!(result.removed, 1);
+        assert_eq!(result.updated, KEEP_COUNT as usize);
+        assert_eq!(
+            get_channels(&conn, Some(playlist_id)).unwrap().len(),
+            KEEP_COUNT as usize
+        );
     }
 
     // ========== Settings Tests ==========

--- a/src-tauri/src/playlist/xtream.rs
+++ b/src-tauri/src/playlist/xtream.rs
@@ -23,9 +23,12 @@ pub struct SeriesInfo {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Season {
+    #[serde(deserialize_with = "de_string_lenient")]
     pub id: String,
     pub name: String,
+    #[serde(deserialize_with = "de_string_lenient")]
     pub season_number: String,
+    #[serde(deserialize_with = "de_i32_lenient")]
     pub episode_count: i32,
     pub air_date: Option<String>,
     pub overview: Option<String>,
@@ -34,10 +37,13 @@ pub struct Season {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Episode {
+    #[serde(deserialize_with = "de_string_lenient")]
     pub id: String,
+    #[serde(deserialize_with = "de_i32_lenient")]
     pub episode_num: i32,
     pub title: String,
     pub container_extension: String,
+    #[serde(deserialize_with = "de_i32_lenient")]
     pub season: i32,
     pub info: EpisodeInfo,
 }
@@ -49,7 +55,63 @@ pub struct EpisodeInfo {
     #[serde(rename = "releaseDate")]
     pub release_date: Option<String>,
     pub duration: Option<String>,
+    #[serde(deserialize_with = "de_opt_f32_lenient", default)]
     pub rating: Option<f32>,
+}
+
+/// Some Xtream providers send string-typed IDs (e.g. `id`, `season_number`) as raw numbers.
+fn de_string_lenient<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    match serde_json::Value::deserialize(deserializer)? {
+        serde_json::Value::String(s) => Ok(s),
+        serde_json::Value::Number(n) => Ok(n.to_string()),
+        other => Err(serde::de::Error::custom(format!(
+            "expected string or number, got {other}"
+        ))),
+    }
+}
+
+/// Some Xtream providers send numeric fields as strings (e.g. "5" instead of 5).
+fn de_i32_lenient<'de, D>(deserializer: D) -> Result<i32, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    match serde_json::Value::deserialize(deserializer)? {
+        serde_json::Value::Number(n) => n
+            .as_i64()
+            .map(|n| n as i32)
+            .ok_or_else(|| serde::de::Error::custom("invalid number")),
+        serde_json::Value::String(s) => {
+            s.trim().parse::<i32>().map_err(serde::de::Error::custom)
+        }
+        other => Err(serde::de::Error::custom(format!(
+            "expected number or string, got {other}"
+        ))),
+    }
+}
+
+/// Same string/number leniency as `de_i32_lenient`, but for an optional float field.
+fn de_opt_f32_lenient<'de, D>(deserializer: D) -> Result<Option<f32>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    match Option::<serde_json::Value>::deserialize(deserializer)? {
+        None | Some(serde_json::Value::Null) => Ok(None),
+        Some(serde_json::Value::Number(n)) => Ok(n.as_f64().map(|f| f as f32)),
+        Some(serde_json::Value::String(s)) => {
+            let s = s.trim();
+            if s.is_empty() {
+                Ok(None)
+            } else {
+                s.parse::<f32>().map(Some).map_err(serde::de::Error::custom)
+            }
+        }
+        Some(other) => Err(serde::de::Error::custom(format!(
+            "expected number, string, or null, got {other}"
+        ))),
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -66,6 +128,57 @@ pub struct SeriesMetadata {
     pub backdrop_path: Option<Vec<String>>,
 }
 
+#[cfg(test)]
+mod lenient_number_tests {
+    use super::{Episode, Season};
+
+    #[test]
+    fn accepts_episode_num_and_season_as_string_or_number() {
+        let as_strings = r#"{"id":"1","episode_num":"3","title":"t","container_extension":"mp4","season":"2","info":{"plot":null,"movie_image":null,"releaseDate":null,"duration":null,"rating":"8.5"}}"#;
+        let ep: Episode = serde_json::from_str(as_strings).unwrap();
+        assert_eq!(ep.episode_num, 3);
+        assert_eq!(ep.season, 2);
+        assert_eq!(ep.info.rating, Some(8.5));
+
+        let as_numbers = r#"{"id":309556,"episode_num":3,"title":"t","container_extension":"mp4","season":2,"info":{"plot":null,"movie_image":null,"releaseDate":null,"duration":null,"rating":8.5}}"#;
+        let ep: Episode = serde_json::from_str(as_numbers).unwrap();
+        assert_eq!(ep.id, "309556");
+        assert_eq!(ep.episode_num, 3);
+        assert_eq!(ep.season, 2);
+        assert_eq!(ep.info.rating, Some(8.5));
+    }
+
+    #[test]
+    fn season_accepts_id_and_season_number_as_string_or_number() {
+        let as_numbers = r#"{"id":309556,"name":"Season 1","season_number":1,"episode_count":10,"air_date":null,"overview":null,"cover":null}"#;
+        let season: Season = serde_json::from_str(as_numbers).unwrap();
+        assert_eq!(season.id, "309556");
+        assert_eq!(season.season_number, "1");
+        assert_eq!(season.episode_count, 10);
+
+        let as_strings = r#"{"id":"309556","name":"Season 1","season_number":"1","episode_count":"10","air_date":null,"overview":null,"cover":null}"#;
+        let season: Season = serde_json::from_str(as_strings).unwrap();
+        assert_eq!(season.id, "309556");
+        assert_eq!(season.season_number, "1");
+        assert_eq!(season.episode_count, 10);
+    }
+
+    #[test]
+    fn rating_accepts_missing_null_and_empty_string() {
+        let missing = r#"{"id":"1","episode_num":1,"title":"t","container_extension":"mp4","season":1,"info":{"plot":null,"movie_image":null,"releaseDate":null,"duration":null}}"#;
+        assert_eq!(
+            serde_json::from_str::<Episode>(missing).unwrap().info.rating,
+            None
+        );
+
+        let empty = r#"{"id":"1","episode_num":1,"title":"t","container_extension":"mp4","season":1,"info":{"plot":null,"movie_image":null,"releaseDate":null,"duration":null,"rating":""}}"#;
+        assert_eq!(
+            serde_json::from_str::<Episode>(empty).unwrap().info.rating,
+            None
+        );
+    }
+}
+
 #[derive(Debug, Deserialize)]
 struct XtreamStream {
     #[allow(dead_code)] // May be used in future for stream ordering
@@ -73,6 +186,7 @@ struct XtreamStream {
     name: String,
     #[serde(alias = "series_id")]
     stream_id: i64,
+    #[serde(alias = "cover")]
     stream_icon: Option<String>,
     category_id: Option<String>,
     #[serde(rename = "type")]
@@ -83,6 +197,23 @@ struct XtreamStream {
 struct XtreamCategory {
     category_id: String,
     category_name: String,
+}
+
+#[cfg(test)]
+mod xtream_stream_tests {
+    use super::XtreamStream;
+
+    #[test]
+    fn accepts_cover_or_stream_icon_for_the_thumbnail_field() {
+        // get_series returns `cover`; get_live_streams/get_vod_streams return `stream_icon`
+        let series_style = r#"{"name":"s","series_id":1,"cover":"http://x/cover.png"}"#;
+        let stream: XtreamStream = serde_json::from_str(series_style).unwrap();
+        assert_eq!(stream.stream_icon.as_deref(), Some("http://x/cover.png"));
+
+        let live_style = r#"{"name":"s","stream_id":1,"stream_icon":"http://x/icon.png"}"#;
+        let stream: XtreamStream = serde_json::from_str(live_style).unwrap();
+        assert_eq!(stream.stream_icon.as_deref(), Some("http://x/icon.png"));
+    }
 }
 
 /// Progress information during channel fetching
@@ -217,8 +348,14 @@ async fn fetch_json_with_retry<T: for<'de> Deserialize<'de>>(
                 .json::<T>()
                 .await
                 .map_err(|e| {
-                    warn!("Failed to parse {} response, retrying: {}", action, e);
-                    backoff::Error::transient(anyhow::anyhow!("Parse failed: {}", e))
+                    let mut detail = e.to_string();
+                    let mut source = std::error::Error::source(&e);
+                    while let Some(s) = source {
+                        detail.push_str(&format!(": {}", s));
+                        source = s.source();
+                    }
+                    warn!("Failed to parse {} response, retrying: {}", action, detail);
+                    backoff::Error::transient(anyhow::anyhow!("Parse failed: {}", detail))
                 })
         }
     })

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -18,7 +18,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; img-src 'self' https: data: blob:; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' https: http:; media-src 'self' https: http: blob:"
+      "csp": "default-src 'self'; img-src 'self' https: http: data: blob:; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' https: http:; media-src 'self' https: http: blob:"
     }
   },
   "bundle": {

--- a/src/components/ProfileManager.tsx
+++ b/src/components/ProfileManager.tsx
@@ -14,6 +14,7 @@ export default function ProfileManager({ onClose }: ProfileManagerProps) {
   const {
     playlists,
     activeProfileId,
+    currentPlaylist,
     setActiveProfileId: setStoreActiveId,
     setCurrentPlaylist,
     setChannels,
@@ -78,6 +79,12 @@ export default function ProfileManager({ onClose }: ProfileManagerProps) {
         p.id === id ? { ...p, name: editName.trim() } : p
       );
       usePlayerStore.setState({ playlists: updatedPlaylists });
+
+      // currentPlaylist is a separate copy in the store, not derived from
+      // playlists — keep it in sync when renaming the active playlist
+      if (currentPlaylist?.id === id) {
+        setCurrentPlaylist({ ...currentPlaylist, name: editName.trim() });
+      }
 
       setEditingId(null);
       logger.info(`Profile ID ${id} renamed to: ${editName.trim()}`);


### PR DESCRIPTION
## Summary
Four independent bugfixes found while working on the TV redesign, unrelated to styling:

- Xtream series API: tolerate mixed string/number types in the response instead of failing to parse
- CSP: allow `http:` images so provider logos served over plain HTTP still load
- SQLite: avoid hitting `SQLITE_MAX_EXPR_DEPTH` when pruning stale channels from large playlists (stage IDs to keep instead of a giant `NOT IN (...)`)
- ProfileManager: `currentPlaylist` is a separate copy of `Playlist` in the store, not derived from `playlists` — renaming the active profile left Settings > General showing the stale name until switch/restart

Each is a standalone fix, safe to review/merge independently of the redesign work.

## Test plan
- [ ] `npm run lint`
- [ ] `cargo clippy` / `cargo test` (src-tauri)
- [ ] Manual: rename active profile, confirm Settings > General updates immediately