### PR TITLE
feat: TV-friendly UI redesign — phase 1 (design tokens + core screens)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ claudedocs/
 docs/*
 !docs/superpowers/
 plans/
+!docs/superpowers/plans/
 
 ## MISC
 VERSION.md

--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,8 @@ CLAUDE.md
 *.claude
 .serena/
 claudedocs/
-docs/
+docs/*
+!docs/superpowers/
 plans/
 
 ## MISC

--- a/docs/superpowers/plans/2026-07-30-tv-redesign.md
+++ b/docs/superpowers/plans/2026-07-30-tv-redesign.md
@@ -1,0 +1,1372 @@
+# TV-Friendly UI Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace Better IPTV's default visual style with a Netflix-style dark theme — fluid, larger typography and cover-forward cards — readable from a couch on a 60" TV, without touching any business logic, hooks, stores, or the Rust backend.
+
+**Architecture:** Introduce a small CSS-variable-backed design-token layer (colors + fluid `clamp()` typography) in `tailwind.config.js` / `src/index.css`, then mechanically restyle each presentation component to consume the new tokens instead of hardcoded Tailwind gray/blue classes and fixed `dark:` variants. All work happens in an isolated git worktree so the currently-shipping build is never at risk.
+
+**Tech Stack:** React 18 + TypeScript + Vite + Tailwind CSS (existing stack, no new dependencies).
+
+## Global Constraints
+
+- Frontend-only (`src/`, `tailwind.config.js`, `src/index.css`). No changes under `src-tauri/`.
+- No changes to hook *logic*, Zustand stores (`src/stores/player-store.ts`), or business logic. The one narrow exception: `src/hooks/useResponsiveGrid.ts` gets its numeric `BREAKPOINTS` tuning constants adjusted (not its logic) so the grid virtualizer's row-height math matches the new, larger card size — this is called out explicitly in Task 8.
+- Existing vitest suite (`src/test/`) must keep passing unmodified — it covers hooks/stores/lib, none of which change behavior here.
+- All work happens in the git worktree `~/Projects/better-iptv-tv-redesign` on branch `feature/tv-redesign`, branched from `main` in `~/Projects/better-iptv` (which already has the 2026-07-29/30 parser/CSP/SQL fixes). `~/Projects/better-iptv` itself is never modified by this plan.
+- No production Tauri *build* (`cargo build --release`) is required to complete this plan — validate visually with `npm run tauri dev` (runs the real Rust IPC backend against the existing dev binary, so screens with real data render correctly; plain `npm run dev` only proves Tailwind/TypeScript compile and is used for that narrower purpose in Task 2). Building the release Tauri binary and cutting over the production install (`/opt/better-iptv-bin/usr/bin/better-ip-tv`) is a deliberate follow-up step *after* the user approves the look live on the TV; it is not part of this plan.
+- MPV embedding is explicitly out of scope (dropped during brainstorming — Wayland/`--wid` reliability risk).
+
+---
+
+## Design tokens (reference for every task below)
+
+New CSS variables added in Task 2, consumed via Tailwind color aliases. Every task after Task 2 uses this exact substitution table when restyling a file:
+
+| Old class(es) | New class |
+|---|---|
+| `bg-gray-50` (light bg), `dark:bg-gray-900` | `bg-bg` (no `dark:` needed — the variable itself swaps) |
+| `bg-white`, `dark:bg-gray-800` (card/panel surface) | `bg-surface` |
+| `bg-gray-100`, `bg-gray-200`, `bg-gray-700`, `dark:bg-gray-700` (hover/secondary surface) | `bg-surface-hover` |
+| `text-gray-900`, `dark:text-white` | `text-text` |
+| `text-gray-400/500/600/700`, `dark:text-gray-300/400` | `text-text-muted` |
+| `border-gray-200/300`, `dark:border-gray-600/700` | `border-border` |
+| `bg-blue-600`, `hover:bg-blue-700` | `bg-accent`, `hover:bg-accent-hover` |
+| `text-blue-600`, `dark:text-blue-400` | `text-accent` |
+| `border-blue-600`, `dark:border-blue-400` | `border-accent` |
+| `focus:ring-blue-500` | `focus:ring-accent` |
+| `text-xs` | `text-fluid-xs` |
+| `text-sm` | `text-fluid-sm` |
+| `text-base` (implicit/default) | `text-fluid-base` |
+| `text-lg` | `text-fluid-lg` |
+| `text-xl` | `text-fluid-xl` |
+| `text-2xl` | `text-fluid-2xl` |
+| `text-3xl` | `text-fluid-3xl` |
+
+Spacing/density gets a flat bump in each task (no new token needed — just larger existing Tailwind values): `p-3`→`p-5`, `p-4`→`p-6`, `gap-2`→`gap-3`, `gap-4`→`gap-6`, `rounded-lg`→`rounded-xl`, `rounded-md`→`rounded-lg`.
+
+---
+
+### Task 1: Create the isolated git worktree
+
+**Files:** none (repo/worktree setup only)
+
+- [ ] **Step 1: Verify the main repo is clean and on `main`**
+
+```bash
+cd ~/Projects/better-iptv
+git status --short
+git branch --show-current
+```
+
+Expected: no uncommitted changes, current branch `main`.
+
+- [ ] **Step 2: Create the worktree on a new branch**
+
+```bash
+git worktree add -b feature/tv-redesign ~/Projects/better-iptv-tv-redesign main
+```
+
+Expected: new directory `~/Projects/better-iptv-tv-redesign` created, checked out on branch `feature/tv-redesign`.
+
+- [ ] **Step 3: Install frontend dependencies in the new worktree**
+
+```bash
+cd ~/Projects/better-iptv-tv-redesign
+npm install
+```
+
+Expected: completes without error (this worktree needs its own `node_modules`; it is not shared with `~/Projects/better-iptv`).
+
+- [ ] **Step 4: Confirm the dev server runs**
+
+```bash
+npm run tauri dev
+```
+
+Expected: the app window opens showing the current (unmodified) UI, connected to the same local SQLite data (`~/.local/share/com.m0s.better-ip-tv/better-ip-tv.db`) as the production install. Stop it (Ctrl+C) once confirmed — subsequent tasks restart it as needed.
+
+> All remaining tasks operate inside `~/Projects/better-iptv-tv-redesign`.
+
+---
+
+### Task 2: Design tokens — Tailwind config + CSS variables
+
+**Files:**
+- Modify: `src/index.css`
+- Modify: `tailwind.config.js`
+
+**Interfaces:**
+- Produces: Tailwind utility classes `bg-bg`, `bg-surface`, `bg-surface-hover`, `text-text`, `text-text-muted`, `border-border`, `bg-accent`, `bg-accent-hover`, `text-accent`, `border-accent`, `focus:ring-accent`, and font sizes `text-fluid-xs` through `text-fluid-3xl`, consumed by every later task.
+
+- [ ] **Step 1: Add CSS variables to `src/index.css`**
+
+Replace the full file content:
+
+```css
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --color-bg: 249 250 251;
+  --color-surface: 255 255 255;
+  --color-surface-hover: 243 244 246;
+  --color-text: 17 24 39;
+  --color-text-muted: 75 85 99;
+  --color-border: 229 231 235;
+  --color-accent: 220 38 38;
+  --color-accent-hover: 185 28 28;
+}
+
+.dark {
+  --color-bg: 3 7 18;
+  --color-surface: 17 24 39;
+  --color-surface-hover: 31 41 55;
+  --color-text: 249 250 251;
+  --color-text-muted: 156 163 175;
+  --color-border: 55 65 81;
+  --color-accent: 239 68 68;
+  --color-accent-hover: 248 113 113;
+}
+```
+
+(Light values reuse Tailwind's own gray-50/100/200/600/900 and red-600/700 scale; dark values use gray-950/900/800/700/400/50 and red-500/400 — no invented colors, and the dark accent is Tailwind's red-500, deliberately not Netflix's exact brand hex, to avoid trademark collision while keeping the "cinematic red accent" feel.)
+
+- [ ] **Step 2: Extend `tailwind.config.js`**
+
+```js
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: [
+    "./index.html",
+    "./src/**/*.{js,ts,jsx,tsx}",
+  ],
+  darkMode: 'class',
+  theme: {
+    extend: {
+      colors: {
+        bg: 'rgb(var(--color-bg) / <alpha-value>)',
+        surface: 'rgb(var(--color-surface) / <alpha-value>)',
+        'surface-hover': 'rgb(var(--color-surface-hover) / <alpha-value>)',
+        text: 'rgb(var(--color-text) / <alpha-value>)',
+        'text-muted': 'rgb(var(--color-text-muted) / <alpha-value>)',
+        border: 'rgb(var(--color-border) / <alpha-value>)',
+        accent: {
+          DEFAULT: 'rgb(var(--color-accent) / <alpha-value>)',
+          hover: 'rgb(var(--color-accent-hover) / <alpha-value>)',
+        },
+      },
+      fontSize: {
+        'fluid-xs': 'clamp(0.75rem, 0.65rem + 0.3vw, 0.9rem)',
+        'fluid-sm': 'clamp(0.875rem, 0.75rem + 0.4vw, 1.125rem)',
+        'fluid-base': 'clamp(1rem, 0.85rem + 0.5vw, 1.375rem)',
+        'fluid-lg': 'clamp(1.125rem, 0.95rem + 0.65vw, 1.625rem)',
+        'fluid-xl': 'clamp(1.375rem, 1.1rem + 1vw, 2rem)',
+        'fluid-2xl': 'clamp(1.75rem, 1.3rem + 1.5vw, 2.75rem)',
+        'fluid-3xl': 'clamp(2.25rem, 1.6rem + 2.25vw, 3.75rem)',
+      },
+    },
+  },
+  plugins: [],
+}
+```
+
+- [ ] **Step 3: Verify the build picks up the new config**
+
+```bash
+npm run dev
+```
+
+Expected: dev server starts without Tailwind/PostCSS errors. Stop it (Ctrl+C).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/index.css tailwind.config.js
+git commit -m "feat(tv-redesign): add design token layer (colors, fluid typography)"
+```
+
+---
+
+### Task 3: Restyle `ChannelCard.tsx`
+
+**Files:**
+- Modify: `src/components/ChannelCard.tsx`
+
+**Interfaces:**
+- Consumes: tokens from Task 2.
+- No prop/signature changes — same `ChannelCardProps` interface, same behavior.
+
+- [ ] **Step 1: Swap the outer card container and logo section (lines 50–68)**
+
+Old:
+```tsx
+    <div
+      className="relative flex flex-col overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm transition-shadow hover:shadow-md dark:border-gray-700 dark:bg-gray-800"
+      style={{ height: `${cardHeight}px` }}
+    >
+      {/* Logo/Image section */}
+      <div className="group relative flex-shrink-0 bg-gray-900">
+        {channel.logo ? (
+          <div
+            className="flex w-full items-center justify-center bg-gray-900 p-2"
+            style={{ height: `${imageHeight}px` }}
+          >
+            <img
+              src={channel.logo}
+              alt={channel.name}
+              loading="lazy"
+              className="max-h-full max-w-full object-contain"
+            />
+          </div>
+        ) : (
+```
+
+New:
+```tsx
+    <div
+      className="relative flex flex-col overflow-hidden rounded-xl border border-border bg-surface shadow-sm transition-shadow hover:shadow-lg"
+      style={{ height: `${cardHeight}px` }}
+    >
+      {/* Logo/Image section */}
+      <div className="group relative flex-shrink-0 bg-bg">
+        {channel.logo ? (
+          <div
+            className="flex w-full items-center justify-center bg-bg"
+            style={{ height: `${imageHeight}px` }}
+          >
+            <img
+              src={channel.logo}
+              alt={channel.name}
+              loading="lazy"
+              className="h-full w-full object-cover"
+            />
+          </div>
+        ) : (
+```
+
+(Note: dropped the `p-2` padding and switched `object-contain` → `object-cover` so the cover image fills the card — the "capa em destaque" the spec calls for — instead of a small centered logo.)
+
+- [ ] **Step 2: Swap the content section text (lines 103–115)**
+
+Old:
+```tsx
+      <div className={`${isLarge ? 'p-4' : isSmall ? 'p-2' : 'p-3'} flex min-h-0 flex-1 flex-col`}>
+        <h3
+          className={`truncate font-medium text-gray-900 dark:text-white ${isLarge ? 'text-base' : 'text-sm'}`}
+        >
+          {channel.name}
+        </h3>
+        {channel.group_name && (
+          <p
+            className={`mt-0.5 truncate text-gray-500 dark:text-gray-400 ${isSmall ? 'text-[10px]' : 'text-xs'}`}
+          >
+            {channel.group_name}
+          </p>
+        )}
+        {currentProgram && channel.content_type === 'live' && (
+          <p
+            className={`mt-0.5 truncate text-blue-600 dark:text-blue-400 ${isSmall ? 'text-[10px]' : 'text-xs'}`}
+            title={currentProgram}
+          >
+            📺 {currentProgram}
+          </p>
+        )}
+```
+
+New:
+```tsx
+      <div className={`${isLarge ? 'p-6' : isSmall ? 'p-3' : 'p-5'} flex min-h-0 flex-1 flex-col`}>
+        <h3
+          className={`truncate font-medium text-text ${isLarge ? 'text-fluid-lg' : 'text-fluid-base'}`}
+        >
+          {channel.name}
+        </h3>
+        {channel.group_name && (
+          <p className="mt-0.5 truncate text-fluid-sm text-text-muted">
+            {channel.group_name}
+          </p>
+        )}
+        {currentProgram && channel.content_type === 'live' && (
+          <p
+            className="mt-0.5 truncate text-fluid-sm text-accent"
+            title={currentProgram}
+          >
+            📺 {currentProgram}
+          </p>
+        )}
+```
+
+- [ ] **Step 3: Swap the action button (lines 127–137)**
+
+Old:
+```tsx
+        <button
+          onClick={() => onPlay(channel)}
+          className={`flex w-full items-center justify-center gap-2 rounded-md font-medium transition-colors ${
+            isLarge ? 'mt-3 px-4 py-2.5' : isSmall ? 'mt-2 px-3 py-1.5 text-sm' : 'mt-2 px-4 py-2'
+          } ${
+            isPlaying
+              ? 'bg-red-600 text-white hover:bg-red-700'
+              : channel.content_type === 'series'
+                ? 'bg-purple-600 text-white hover:bg-purple-700'
+                : 'bg-blue-600 text-white hover:bg-blue-700'
+          }`}
+        >
+```
+
+New:
+```tsx
+        <button
+          onClick={() => onPlay(channel)}
+          className={`flex w-full items-center justify-center gap-2 rounded-lg font-medium text-fluid-sm transition-colors ${
+            isLarge ? 'mt-4 px-5 py-3' : isSmall ? 'mt-3 px-4 py-2' : 'mt-3 px-5 py-2.5'
+          } ${
+            isPlaying
+              ? 'bg-red-600 text-white hover:bg-red-700'
+              : channel.content_type === 'series'
+                ? 'bg-purple-600 text-white hover:bg-purple-700'
+                : 'bg-accent text-white hover:bg-accent-hover'
+          }`}
+        >
+```
+
+(Kept `bg-red-600`/`bg-purple-600` as-is — those are semantic state colors, "stop" and "series," not the generic accent, so they're intentionally left out of the token substitution.)
+
+- [ ] **Step 4: Type-check and visually verify**
+
+```bash
+npx tsc --noEmit
+npm run tauri dev
+```
+
+Confirm channel cards render with the new colors/fonts (real data, since `tauri dev` runs the actual Rust IPC backend) and no console errors. Close the app window.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/ChannelCard.tsx
+git commit -m "feat(tv-redesign): restyle ChannelCard with design tokens and cover-forward image"
+```
+
+---
+
+### Task 4: Restyle `NowPlayingBar.tsx`
+
+**Files:**
+- Modify: `src/components/NowPlayingBar.tsx`
+
+**Interfaces:**
+- Consumes: tokens from Task 2. No prop changes.
+
+- [ ] **Step 1: Replace the full JSX body**
+
+Old (lines 31–69):
+```tsx
+  return (
+    <div className="bg-blue-600 p-4 text-white">
+      <div className="mx-auto flex items-center justify-between px-2">
+        <div className="flex items-center gap-4">
+          {channel.logo && (
+            <div className="flex h-12 w-12 items-center justify-center rounded bg-gray-900 p-1">
+              <img
+                src={channel.logo}
+                alt={channel.name}
+                className="max-h-full max-w-full object-contain"
+                loading="lazy"
+              />
+            </div>
+          )}
+          <div>
+            <p className="font-medium">{channel.name}</p>
+            <p className="text-sm text-blue-100">{channel.group_name || 'Live TV'}</p>
+            {currentProgram && (
+              <p className="mt-1 text-sm text-blue-200">
+                <span className="font-medium">Now showing:</span> {currentProgram}
+              </p>
+            )}
+            {nextProgram && (
+              <p className="mt-0.5 text-xs text-blue-200">
+                <span className="font-medium">Next up:</span> {nextProgram}
+              </p>
+            )}
+          </div>
+        </div>
+        <button
+          onClick={onStop}
+          className="rounded-lg bg-white/20 p-2 transition-colors hover:bg-white/30"
+          aria-label="Stop playback"
+        >
+          <Square className="h-5 w-5" />
+        </button>
+      </div>
+    </div>
+  );
+```
+
+New:
+```tsx
+  return (
+    <div className="bg-accent p-6 text-white">
+      <div className="mx-auto flex items-center justify-between px-2">
+        <div className="flex items-center gap-4">
+          {channel.logo && (
+            <div className="flex h-16 w-16 items-center justify-center overflow-hidden rounded-lg bg-black/20">
+              <img
+                src={channel.logo}
+                alt={channel.name}
+                className="h-full w-full object-cover"
+                loading="lazy"
+              />
+            </div>
+          )}
+          <div>
+            <p className="text-fluid-lg font-medium">{channel.name}</p>
+            <p className="text-fluid-sm text-white/80">{channel.group_name || 'Live TV'}</p>
+            {currentProgram && (
+              <p className="mt-1 text-fluid-sm text-white/90">
+                <span className="font-medium">Now showing:</span> {currentProgram}
+              </p>
+            )}
+            {nextProgram && (
+              <p className="mt-0.5 text-fluid-xs text-white/70">
+                <span className="font-medium">Next up:</span> {nextProgram}
+              </p>
+            )}
+          </div>
+        </div>
+        <button
+          onClick={onStop}
+          className="rounded-lg bg-white/20 p-3 transition-colors hover:bg-white/30"
+          aria-label="Stop playback"
+        >
+          <Square className="h-6 w-6" />
+        </button>
+      </div>
+    </div>
+  );
+```
+
+- [ ] **Step 2: Type-check and visually verify**
+
+```bash
+npx tsc --noEmit
+npm run tauri dev
+```
+
+Play a channel and confirm the now-playing bar shows the new accent color, larger cover thumbnail, and larger text. Close the app window.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/NowPlayingBar.tsx
+git commit -m "feat(tv-redesign): restyle NowPlayingBar with design tokens"
+```
+
+---
+
+### Task 5: Restyle `CategoryBar.tsx` and `ContentTypeTabs.tsx`
+
+**Files:**
+- Modify: `src/components/CategoryBar.tsx`
+- Modify: `src/components/ContentTypeTabs.tsx`
+
+**Interfaces:**
+- Consumes: tokens from Task 2. No prop/behavior changes to either component.
+
+- [ ] **Step 1: Replace `CategoryBar.tsx`'s JSX (lines 16–54)**
+
+Old:
+```tsx
+  return (
+    <div
+      className="scrollbar-hide flex gap-2 overflow-x-auto bg-gray-800/50 px-4 py-3 pb-6"
+      role="tablist"
+      aria-label="Channel categories"
+    >
+      {/* "All" chip - shows all channels in current content type */}
+      <button
+        onClick={() => setCategoryFilter(null)}
+        role="tab"
+        aria-selected={categoryFilter === null}
+        className={`shrink-0 rounded-full px-3 py-1.5 text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-gray-900 ${
+          categoryFilter === null
+            ? 'bg-blue-600 text-white'
+            : 'bg-gray-700 text-gray-300 hover:bg-gray-600'
+        } `}
+      >
+        All
+      </button>
+
+      {/* Category chips from provider */}
+      {categories.map((category) => (
+        <button
+          key={category}
+          onClick={() => setCategoryFilter(category)}
+          role="tab"
+          aria-selected={categoryFilter === category}
+          className={`shrink-0 whitespace-nowrap rounded-full px-3 py-1.5 text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-gray-900 ${
+            categoryFilter === category
+              ? 'bg-blue-600 text-white'
+              : 'bg-gray-700 text-gray-300 hover:bg-gray-600'
+          } `}
+        >
+          {category}
+        </button>
+      ))}
+    </div>
+  );
+```
+
+New:
+```tsx
+  return (
+    <div
+      className="scrollbar-hide flex gap-3 overflow-x-auto bg-bg px-6 py-4 pb-8"
+      role="tablist"
+      aria-label="Channel categories"
+    >
+      {/* "All" chip - shows all channels in current content type */}
+      <button
+        onClick={() => setCategoryFilter(null)}
+        role="tab"
+        aria-selected={categoryFilter === null}
+        className={`shrink-0 rounded-full px-4 py-2 text-fluid-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 focus:ring-offset-bg ${
+          categoryFilter === null
+            ? 'bg-accent text-white'
+            : 'bg-surface-hover text-text-muted hover:bg-surface'
+        } `}
+      >
+        All
+      </button>
+
+      {/* Category chips from provider */}
+      {categories.map((category) => (
+        <button
+          key={category}
+          onClick={() => setCategoryFilter(category)}
+          role="tab"
+          aria-selected={categoryFilter === category}
+          className={`shrink-0 whitespace-nowrap rounded-full px-4 py-2 text-fluid-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 focus:ring-offset-bg ${
+            categoryFilter === category
+              ? 'bg-accent text-white'
+              : 'bg-surface-hover text-text-muted hover:bg-surface'
+          } `}
+        >
+          {category}
+        </button>
+      ))}
+    </div>
+  );
+```
+
+- [ ] **Step 2: Replace `ContentTypeTabs.tsx`'s JSX (lines 47–72)**
+
+Old:
+```tsx
+  return (
+    <div className="border-b border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
+      <div className="mx-auto px-6">
+        <div className="flex gap-2 overflow-x-auto" role="tablist" aria-label="Content type filter">
+          {TABS.map((tab) => (
+            <button
+              key={tab.value}
+              role="tab"
+              aria-selected={activeFilter === tab.value}
+              aria-controls="channel-list"
+              onClick={() => onFilterChange(tab.value)}
+              className={`flex items-center gap-2 whitespace-nowrap border-b-2 px-4 py-3 font-medium transition-colors ${
+                activeFilter === tab.value
+                  ? 'border-blue-600 text-blue-600 dark:border-blue-400 dark:text-blue-400'
+                  : 'border-transparent text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-200'
+              }`}
+            >
+              {tab.icon}
+              {tab.label}
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+```
+
+New:
+```tsx
+  return (
+    <div className="border-b border-border bg-surface">
+      <div className="mx-auto px-6">
+        <div className="flex gap-3 overflow-x-auto" role="tablist" aria-label="Content type filter">
+          {TABS.map((tab) => (
+            <button
+              key={tab.value}
+              role="tab"
+              aria-selected={activeFilter === tab.value}
+              aria-controls="channel-list"
+              onClick={() => onFilterChange(tab.value)}
+              className={`flex items-center gap-2 whitespace-nowrap border-b-2 px-5 py-4 text-fluid-base font-medium transition-colors ${
+                activeFilter === tab.value
+                  ? 'border-accent text-accent'
+                  : 'border-transparent text-text-muted hover:text-text'
+              }`}
+            >
+              {tab.icon}
+              {tab.label}
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+```
+
+- [ ] **Step 3: Type-check and visually verify**
+
+```bash
+npx tsc --noEmit
+npm run tauri dev
+```
+
+Confirm category chips and content-type tabs render with the new tokens, and switching tabs/categories still filters correctly (behavior untouched — only classes changed). Close the app window.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/CategoryBar.tsx src/components/ContentTypeTabs.tsx
+git commit -m "feat(tv-redesign): restyle CategoryBar and ContentTypeTabs with design tokens"
+```
+
+---
+
+### Task 6: Restyle `MainScreen.tsx` header/shell
+
+**Files:**
+- Modify: `src/components/MainScreen.tsx:271-309` (header + grid container wrapper only — the virtualization logic at lines 316-365 is untouched except the `gap-4` → `gap-6` class noted below)
+
+**Interfaces:**
+- Consumes: tokens from Task 2. No changes to any hook call, state, or the virtualizer setup.
+
+- [ ] **Step 1: Replace the header block (lines 271–290)**
+
+Old:
+```tsx
+  return (
+    <div className="flex h-screen flex-col bg-gray-50 dark:bg-gray-900">
+      {/* Header */}
+      <div className="border-b border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
+        <div className="mx-auto flex items-center justify-between px-2">
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Better IPTV</h1>
+          <div className="flex items-center gap-4">
+            <span className="text-sm text-gray-600 dark:text-gray-400">
+              {channels.length} channels
+            </span>
+            <button
+              onClick={() => setShowSettings(true)}
+              className="rounded-lg p-2 transition-colors hover:bg-gray-100 dark:hover:bg-gray-700"
+              title="Settings"
+            >
+              <SettingsIcon className="h-5 w-5 text-gray-600 dark:text-gray-400" />
+            </button>
+          </div>
+        </div>
+      </div>
+```
+
+New:
+```tsx
+  return (
+    <div className="flex h-screen flex-col bg-bg">
+      {/* Header */}
+      <div className="border-b border-border bg-surface p-6">
+        <div className="mx-auto flex items-center justify-between px-2">
+          <h1 className="text-fluid-2xl font-bold text-text">Better IPTV</h1>
+          <div className="flex items-center gap-6">
+            <span className="text-fluid-sm text-text-muted">
+              {channels.length} channels
+            </span>
+            <button
+              onClick={() => setShowSettings(true)}
+              className="rounded-lg p-3 transition-colors hover:bg-surface-hover"
+              title="Settings"
+            >
+              <SettingsIcon className="h-6 w-6 text-text-muted" />
+            </button>
+          </div>
+        </div>
+      </div>
+```
+
+- [ ] **Step 2: Update the grid container and empty-state text (lines 302–315)**
+
+Old:
+```tsx
+      <div
+        ref={parentRef}
+        className="flex-1 overflow-y-auto"
+        id="channel-list"
+        role="tabpanel"
+        aria-label="Channel list"
+      >
+        <div className="mx-auto p-4">
+          {filteredChannels.length === 0 ? (
+            <div className="py-12 text-center">
+              <p className="text-gray-500 dark:text-gray-400">
+                {searchQuery ? 'No channels found' : 'No channels available'}
+              </p>
+            </div>
+          ) : (
+```
+
+New:
+```tsx
+      <div
+        ref={parentRef}
+        className="flex-1 overflow-y-auto"
+        id="channel-list"
+        role="tabpanel"
+        aria-label="Channel list"
+      >
+        <div className="mx-auto p-6">
+          {filteredChannels.length === 0 ? (
+            <div className="py-12 text-center">
+              <p className="text-fluid-base text-text-muted">
+                {searchQuery ? 'No channels found' : 'No channels available'}
+              </p>
+            </div>
+          ) : (
+```
+
+- [ ] **Step 3: Widen the grid gap (line 340)**
+
+Old:
+```tsx
+                    <div className={`grid ${getGridClasses(columns)} gap-4`}>
+```
+
+New:
+```tsx
+                    <div className={`grid ${getGridClasses(columns)} gap-6`}>
+```
+
+> This gap change must land together with Task 8's `useResponsiveGrid.ts` update — both affect the row-height math the virtualizer relies on.
+
+- [ ] **Step 4: Type-check and visually verify**
+
+```bash
+npx tsc --noEmit
+npm run tauri dev
+```
+
+Confirm the header, empty state, and grid spacing use the new tokens, and the channel grid still scrolls smoothly (virtualization untouched). Close the app window.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/MainScreen.tsx
+git commit -m "feat(tv-redesign): restyle MainScreen header and grid shell with design tokens"
+```
+
+---
+
+### Task 7: Restyle `SeriesView.tsx`
+
+**Files:**
+- Modify: `src/components/SeriesView.tsx`
+
+**Interfaces:**
+- Consumes: tokens from Task 2. No changes to data loading, state, or `EpisodeCard` props.
+
+- [ ] **Step 1: Replace the loading and error states (lines 62–93)**
+
+Old:
+```tsx
+  if (isLoading) {
+    return (
+      <div className="flex h-screen flex-col bg-gray-50 dark:bg-gray-900">
+        <div className="flex flex-1 items-center justify-center">
+          <div className="text-center">
+            <div className="mx-auto mb-4 h-16 w-16 animate-spin rounded-full border-4 border-blue-500 border-t-transparent"></div>
+            <p className="font-medium text-gray-700 dark:text-gray-300">Loading series...</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (error || !currentSeries) {
+    return (
+      <div className="flex h-screen flex-col bg-gray-50 dark:bg-gray-900">
+        <div className="flex flex-1 items-center justify-center">
+          <div className="text-center">
+            <p className="mb-4 font-medium text-red-600 dark:text-red-400">
+              {error || 'Failed to load series'}
+            </p>
+            <button
+              onClick={onBack}
+              className="rounded-md bg-blue-600 px-4 py-2 text-white hover:bg-blue-700"
+            >
+              Go Back
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+```
+
+New:
+```tsx
+  if (isLoading) {
+    return (
+      <div className="flex h-screen flex-col bg-bg">
+        <div className="flex flex-1 items-center justify-center">
+          <div className="text-center">
+            <div className="mx-auto mb-4 h-16 w-16 animate-spin rounded-full border-4 border-accent border-t-transparent"></div>
+            <p className="text-fluid-base font-medium text-text-muted">Loading series...</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (error || !currentSeries) {
+    return (
+      <div className="flex h-screen flex-col bg-bg">
+        <div className="flex flex-1 items-center justify-center">
+          <div className="text-center">
+            <p className="mb-4 text-fluid-base font-medium text-red-600 dark:text-red-400">
+              {error || 'Failed to load series'}
+            </p>
+            <button
+              onClick={onBack}
+              className="rounded-lg bg-accent px-5 py-2.5 text-white hover:bg-accent-hover"
+            >
+              Go Back
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+```
+
+(Kept `text-red-600 dark:text-red-400` for the error message — semantic error color, not the accent.)
+
+- [ ] **Step 2: Replace the header block (lines 97–134)**
+
+Old:
+```tsx
+  return (
+    <div className="flex h-screen flex-col bg-gray-50 dark:bg-gray-900">
+      {/* Header */}
+      <div className="border-b border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
+        <div className="mx-auto max-w-7xl">
+          <button
+            onClick={onBack}
+            className="mb-4 flex items-center gap-2 text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
+          >
+            <ChevronLeft className="h-5 w-5" />
+            Back to Series List
+          </button>
+          <div className="flex gap-6">
+            {currentSeries.info.cover && (
+              <img
+                src={currentSeries.info.cover}
+                alt={currentSeries.info.name}
+                className="h-48 w-32 rounded-lg object-cover"
+              />
+            )}
+            <div className="flex-1">
+              <h1 className="mb-2 text-3xl font-bold text-gray-900 dark:text-white">
+                {currentSeries.info.name}
+              </h1>
+              {currentSeries.info.genre && (
+                <p className="mb-2 text-sm text-gray-600 dark:text-gray-400">
+                  {currentSeries.info.genre}
+                </p>
+              )}
+              {currentSeries.info.plot && (
+                <p className="line-clamp-3 text-gray-700 dark:text-gray-300">
+                  {currentSeries.info.plot}
+                </p>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+```
+
+New:
+```tsx
+  return (
+    <div className="flex h-screen flex-col bg-bg">
+      {/* Header */}
+      <div className="border-b border-border bg-surface p-6">
+        <div className="mx-auto max-w-7xl">
+          <button
+            onClick={onBack}
+            className="mb-6 flex items-center gap-2 text-fluid-sm text-accent hover:text-accent-hover"
+          >
+            <ChevronLeft className="h-5 w-5" />
+            Back to Series List
+          </button>
+          <div className="flex gap-8">
+            {currentSeries.info.cover && (
+              <img
+                src={currentSeries.info.cover}
+                alt={currentSeries.info.name}
+                className="h-72 w-48 rounded-xl object-cover shadow-lg"
+              />
+            )}
+            <div className="flex-1">
+              <h1 className="mb-3 text-fluid-3xl font-bold text-text">
+                {currentSeries.info.name}
+              </h1>
+              {currentSeries.info.genre && (
+                <p className="mb-3 text-fluid-sm text-text-muted">
+                  {currentSeries.info.genre}
+                </p>
+              )}
+              {currentSeries.info.plot && (
+                <p className="line-clamp-3 text-fluid-base text-text-muted">
+                  {currentSeries.info.plot}
+                </p>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+```
+
+- [ ] **Step 3: Replace the season selector (lines 136–155)**
+
+Old:
+```tsx
+      {/* Season Selector */}
+      <div className="border-b border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
+        <div className="mx-auto max-w-7xl px-4">
+          <div className="flex gap-2 overflow-x-auto py-4">
+            {currentSeries.seasons.map((season) => (
+              <button
+                key={season.id}
+                onClick={() => setSelectedSeason(season.season_number)}
+                className={`whitespace-nowrap rounded-md px-4 py-2 font-medium transition-colors ${
+                  selectedSeason === season.season_number
+                    ? 'bg-blue-600 text-white'
+                    : 'bg-gray-200 text-gray-900 hover:bg-gray-300 dark:bg-gray-700 dark:text-white dark:hover:bg-gray-600'
+                }`}
+              >
+                {season.name} ({season.episode_count})
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+```
+
+New:
+```tsx
+      {/* Season Selector */}
+      <div className="border-b border-border bg-surface">
+        <div className="mx-auto max-w-7xl px-6">
+          <div className="flex gap-3 overflow-x-auto py-5">
+            {currentSeries.seasons.map((season) => (
+              <button
+                key={season.id}
+                onClick={() => setSelectedSeason(season.season_number)}
+                className={`whitespace-nowrap rounded-lg px-5 py-2.5 text-fluid-sm font-medium transition-colors ${
+                  selectedSeason === season.season_number
+                    ? 'bg-accent text-white'
+                    : 'bg-surface-hover text-text hover:bg-border'
+                }`}
+              >
+                {season.name} ({season.episode_count})
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+```
+
+- [ ] **Step 4: Replace the episode list wrapper and empty state (lines 157–166)**
+
+Old:
+```tsx
+      {/* Episode List */}
+      <div className="flex-1 overflow-y-auto">
+        <div className="mx-auto max-w-7xl p-4">
+          {selectedSeasonEpisodes.length === 0 ? (
+            <div className="py-12 text-center">
+              <p className="text-gray-500 dark:text-gray-400">
+                No episodes available for this season
+              </p>
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+```
+
+New:
+```tsx
+      {/* Episode List */}
+      <div className="flex-1 overflow-y-auto">
+        <div className="mx-auto max-w-7xl p-6">
+          {selectedSeasonEpisodes.length === 0 ? (
+            <div className="py-12 text-center">
+              <p className="text-fluid-base text-text-muted">
+                No episodes available for this season
+              </p>
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+```
+
+- [ ] **Step 5: Replace the `EpisodeCard` component (lines 207–245)**
+
+Old:
+```tsx
+function EpisodeCard({ episode, onPlay }: EpisodeCardProps) {
+  return (
+    <div className="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm transition-shadow hover:shadow-md dark:border-gray-700 dark:bg-gray-800">
+      <div className="relative bg-gray-900">
+        {episode.info.movie_image ? (
+          <img
+            src={episode.info.movie_image}
+            alt={episode.title}
+            className="h-48 w-full object-cover"
+          />
+        ) : (
+          <div className="flex h-48 w-full items-center justify-center bg-gradient-to-br from-blue-500 to-purple-600">
+            <span className="text-4xl font-bold text-white">E{episode.episode_num}</span>
+          </div>
+        )}
+      </div>
+      <div className="p-3">
+        <h3 className="mb-1 line-clamp-2 font-medium text-gray-900 dark:text-white">
+          Episode {episode.episode_num}
+        </h3>
+        <p className="mb-2 line-clamp-1 text-sm text-gray-700 dark:text-gray-300">
+          {episode.title}
+        </p>
+        {episode.info.plot && (
+          <p className="mb-3 line-clamp-2 text-xs text-gray-600 dark:text-gray-400">
+            {episode.info.plot}
+          </p>
+        )}
+        <button
+          onClick={onPlay}
+          className="flex w-full items-center justify-center gap-2 rounded-md bg-blue-600 px-4 py-2 font-medium text-white transition-colors hover:bg-blue-700"
+        >
+          <Play className="h-4 w-4" />
+          Play
+        </button>
+      </div>
+    </div>
+  );
+}
+```
+
+New:
+```tsx
+function EpisodeCard({ episode, onPlay }: EpisodeCardProps) {
+  return (
+    <div className="overflow-hidden rounded-xl border border-border bg-surface shadow-sm transition-shadow hover:shadow-lg">
+      <div className="relative bg-bg">
+        {episode.info.movie_image ? (
+          <img
+            src={episode.info.movie_image}
+            alt={episode.title}
+            className="h-56 w-full object-cover"
+          />
+        ) : (
+          <div className="flex h-56 w-full items-center justify-center bg-gradient-to-br from-accent to-purple-600">
+            <span className="text-fluid-2xl font-bold text-white">E{episode.episode_num}</span>
+          </div>
+        )}
+      </div>
+      <div className="p-5">
+        <h3 className="mb-1 line-clamp-2 text-fluid-base font-medium text-text">
+          Episode {episode.episode_num}
+        </h3>
+        <p className="mb-2 line-clamp-1 text-fluid-sm text-text-muted">
+          {episode.title}
+        </p>
+        {episode.info.plot && (
+          <p className="mb-3 line-clamp-2 text-fluid-xs text-text-muted">
+            {episode.info.plot}
+          </p>
+        )}
+        <button
+          onClick={onPlay}
+          className="flex w-full items-center justify-center gap-2 rounded-lg bg-accent px-5 py-2.5 text-fluid-sm font-medium text-white transition-colors hover:bg-accent-hover"
+        >
+          <Play className="h-4 w-4" />
+          Play
+        </button>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 6: Type-check and visually verify**
+
+```bash
+npx tsc --noEmit
+npm run tauri dev
+```
+
+Open a series and confirm the header, season chips, and episode cards use the new tokens, larger cover art, and fluid text. Close the app window.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/components/SeriesView.tsx
+git commit -m "feat(tv-redesign): restyle SeriesView with design tokens and larger cover art"
+```
+
+---
+
+### Task 8: Tune `useResponsiveGrid.ts` constants for the larger card design
+
+**Files:**
+- Modify: `src/hooks/useResponsiveGrid.ts:18-31` (constants only — `calculateGridConfig`/`useResponsiveGrid`/`getGridClasses` logic is unchanged)
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: same `GridConfig` shape (`{ columns, cardHeight, estimatedRowHeight, gap }`) — only the numeric values change, not the type or the function signatures used by `MainScreen.tsx`.
+
+- [ ] **Step 1: Update the breakpoint table and gap constant**
+
+Old (lines 18–27):
+```ts
+const BREAKPOINTS: BreakpointConfig[] = [
+  { minWidth: 0, columns: 2, minCardHeight: 200, maxCardHeight: 240 },
+  { minWidth: 640, columns: 3, minCardHeight: 220, maxCardHeight: 260 },
+  { minWidth: 1024, columns: 4, minCardHeight: 240, maxCardHeight: 300 },
+  { minWidth: 1440, columns: 5, minCardHeight: 260, maxCardHeight: 320 },
+  { minWidth: 1920, columns: 6, minCardHeight: 280, maxCardHeight: 360 },
+  { minWidth: 2560, columns: 7, minCardHeight: 300, maxCardHeight: 400 },
+];
+
+const GAP = 16; // Tailwind gap-4
+```
+
+New:
+```ts
+const BREAKPOINTS: BreakpointConfig[] = [
+  { minWidth: 0, columns: 2, minCardHeight: 240, maxCardHeight: 300 },
+  { minWidth: 640, columns: 3, minCardHeight: 260, maxCardHeight: 320 },
+  { minWidth: 1024, columns: 4, minCardHeight: 300, maxCardHeight: 380 },
+  { minWidth: 1440, columns: 4, minCardHeight: 340, maxCardHeight: 420 },
+  { minWidth: 1920, columns: 5, minCardHeight: 380, maxCardHeight: 480 },
+  { minWidth: 2560, columns: 6, minCardHeight: 420, maxCardHeight: 540 },
+];
+
+const GAP = 24; // Tailwind gap-6 (Task 6 widened the grid gap to match)
+```
+
+(Fewer, larger columns at every breakpoint — trades density for the larger, cover-forward cards from Task 3. `minWidth: 1440` now caps at 4 columns instead of 5, since a 60" TV viewed from a couch benefits more from bigger cards than more columns.)
+
+- [ ] **Step 2: Type-check and visually verify**
+
+```bash
+npx tsc --noEmit
+npm run tauri dev
+```
+
+Resize the window through a few widths and confirm the grid re-flows without cards clipping or overlapping (the virtualizer's row-height math now matches the actual rendered card height). Close the app window.
+
+- [ ] **Step 3: Run the existing hook test suite to confirm no regression**
+
+```bash
+npm run test:run -- useResponsiveGrid
+```
+
+Expected: no test file exists yet for this hook (check `src/test/hooks/`) — if `test:run` reports "no tests found" for this pattern, that's expected and fine; the broader suite is re-checked in Task 11.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/hooks/useResponsiveGrid.ts
+git commit -m "feat(tv-redesign): tune grid breakpoint constants for larger card design"
+```
+
+---
+
+### Task 9: Restyle the shared `ui/tabs.tsx` primitive
+
+**Files:**
+- Modify: `src/components/ui/tabs.tsx`
+
+**Interfaces:**
+- Consumes: tokens from Task 2.
+- Produces: same `Tabs`, `TabsList`, `TabsTrigger`, `TabsContent` exports, same props (thin wrapper over `@radix-ui/react-tabs`) — consumed by `Settings.tsx` in Task 10.
+
+- [ ] **Step 1: Replace `TabsList`'s className (line 14–17)**
+
+Old:
+```tsx
+    className={cn(
+      'inline-flex h-12 w-full items-center justify-center border-b border-gray-200 text-gray-500 dark:border-gray-700 dark:text-gray-400',
+      className
+    )}
+```
+
+New:
+```tsx
+    className={cn(
+      'inline-flex h-14 w-full items-center justify-center border-b border-border text-text-muted',
+      className
+    )}
+```
+
+- [ ] **Step 2: Replace `TabsTrigger`'s className (line 29–32)**
+
+Old:
+```tsx
+    className={cn(
+      'inline-flex items-center justify-center whitespace-nowrap border-b-2 border-transparent px-4 py-3 text-sm font-medium text-gray-600 transition-all hover:text-gray-900 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 data-[state=active]:border-blue-600 data-[state=active]:text-blue-600 dark:text-gray-400 dark:hover:text-gray-200 dark:data-[state=active]:border-blue-500 dark:data-[state=active]:text-blue-500',
+      className
+    )}
+```
+
+New:
+```tsx
+    className={cn(
+      'inline-flex items-center justify-center whitespace-nowrap border-b-2 border-transparent px-5 py-4 text-fluid-sm font-medium text-text-muted transition-all hover:text-text focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 data-[state=active]:border-accent data-[state=active]:text-accent',
+      className
+    )}
+```
+
+- [ ] **Step 3: Type-check and visually verify**
+
+```bash
+npx tsc --noEmit
+npm run tauri dev
+```
+
+Open Settings and confirm the tab bar (General/Playback/Parental/About) uses the new tokens. Close the app window.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/ui/tabs.tsx
+git commit -m "feat(tv-redesign): restyle shared tabs primitive with design tokens"
+```
+
+---
+
+### Task 10: Restyle `Settings.tsx` shell and the four settings tabs
+
+**Files:**
+- Modify: `src/components/Settings.tsx` (modal shell only — header/close button/tab list wrapper; the large amount of state/logic in this file is untouched)
+- Modify: `src/components/settings/GeneralTab.tsx`
+- Modify: `src/components/settings/PlaybackTab.tsx`
+- Modify: `src/components/settings/ParentalTab.tsx`
+- Modify: `src/components/settings/AboutTab.tsx`
+
+**Interfaces:**
+- Consumes: tokens from Task 2, `Tabs`/`TabsList`/`TabsTrigger`/`TabsContent` from Task 9.
+- No prop or state changes to any of these files — apply the substitution table from the top of this plan directly to every className in these five files.
+
+- [ ] **Step 1: Find the modal shell in `Settings.tsx` and swap its container classes**
+
+```bash
+grep -n "fixed inset-0\|bg-white\|dark:bg-gray-800\|border-gray-200\|dark:border-gray-700" src/components/Settings.tsx | head -20
+```
+
+For each match in the modal's outer wrapper/header (not inside form logic), apply: `bg-white` / `dark:bg-gray-800` → `bg-surface`; `border-gray-200` / `dark:border-gray-700` → `border-border`; `text-gray-900` / `dark:text-white` → `text-text`; `text-gray-500` / `dark:text-gray-400` → `text-text-muted`. Use the Edit tool for each match with enough surrounding context to target it uniquely (do not use `replace_all` blindly — verify each hit is presentation, not inside an unrelated conditional).
+
+- [ ] **Step 2: Apply the substitution table to all four settings tab files**
+
+For each of `GeneralTab.tsx`, `PlaybackTab.tsx`, `ParentalTab.tsx`, `AboutTab.tsx`, run:
+
+```bash
+grep -c "gray-\|blue-600\|blue-500\|blue-400\|blue-700\|text-xs\|text-sm\|text-base\|text-lg\|text-xl\|text-2xl\|text-3xl" src/components/settings/GeneralTab.tsx src/components/settings/PlaybackTab.tsx src/components/settings/ParentalTab.tsx src/components/settings/AboutTab.tsx
+```
+
+Then, file by file, apply the exact substitution table from the top of this plan (`bg-gray-50`→`bg-bg`, `bg-white`/`dark:bg-gray-800`→`bg-surface`, `bg-gray-100`/`bg-gray-200`/`bg-gray-700`/`dark:bg-gray-700`→`bg-surface-hover`, `text-gray-900`/`dark:text-white`→`text-text`, `text-gray-400/500/600/700`/`dark:text-gray-300/400`→`text-text-muted`, `border-gray-200/300`/`dark:border-gray-600/700`→`border-border`, `bg-blue-600`/`hover:bg-blue-700`→`bg-accent`/`hover:bg-accent-hover`, `text-blue-600`/`dark:text-blue-400`→`text-accent`, `border-blue-600`/`dark:border-blue-400`→`border-accent`, `focus:ring-blue-500`→`focus:ring-accent`, `text-xs`→`text-fluid-xs`, `text-sm`→`text-fluid-sm`, `text-base`→`text-fluid-base`, `text-lg`→`text-fluid-lg`, `text-xl`→`text-fluid-xl`, `text-2xl`→`text-fluid-2xl`, `text-3xl`→`text-fluid-3xl`). Use one `Edit` call per distinct old/new class combination found (there will be several per file — each is a real, mechanical substitution, not a judgment call), with `replace_all: true` where the exact same class string repeats verbatim across the file.
+
+- [ ] **Step 3: Type-check and visually verify**
+
+```bash
+npx tsc --noEmit
+npm run tauri dev
+```
+
+Open Settings and click through all four tabs (General, Playback, Parental, About). Confirm every label, input, toggle, and button uses the new tokens/fluid sizes and nothing is left with a stray `gray-`/`blue-` class (spot-check with the same `grep -c` command from Step 2 — count should be 0 or only semantic exceptions like error/success colors). Close the app window.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/Settings.tsx src/components/settings/GeneralTab.tsx src/components/settings/PlaybackTab.tsx src/components/settings/ParentalTab.tsx src/components/settings/AboutTab.tsx
+git commit -m "feat(tv-redesign): restyle Settings shell and tabs with design tokens"
+```
+
+---
+
+### Task 11: Full-suite validation and manual TV checklist
+
+**Files:** none (validation only)
+
+- [ ] **Step 1: Run the full vitest suite**
+
+```bash
+npm run test:run
+```
+
+Expected: all existing tests pass unchanged (this plan touched no hook logic, store logic, or lib code — only JSX/className).
+
+- [ ] **Step 2: Run a full type-check and production frontend build**
+
+```bash
+npx tsc --noEmit
+npm run build
+```
+
+Expected: both succeed with no errors. This validates the frontend alone (`dist/`) — it does not build the Tauri binary.
+
+- [ ] **Step 3: Run a final grep sweep for leftover old classes across all touched files**
+
+```bash
+grep -rn "bg-gray-\|text-gray-\|border-gray-\|bg-blue-6\|text-blue-6\|border-blue-6\|focus:ring-blue-5" \
+  src/components/ChannelCard.tsx \
+  src/components/NowPlayingBar.tsx \
+  src/components/CategoryBar.tsx \
+  src/components/ContentTypeTabs.tsx \
+  src/components/MainScreen.tsx \
+  src/components/SeriesView.tsx \
+  src/components/ui/tabs.tsx \
+  src/components/Settings.tsx \
+  src/components/settings/*.tsx
+```
+
+Expected: no matches (or only intentional semantic-color exceptions called out in Tasks 3/7, e.g. `bg-red-600`/`text-red-600` for stop/error states, `bg-purple-600` for the series button). Fix any stragglers found and amend the relevant task's commit with a small follow-up commit.
+
+- [ ] **Step 4: Manual TV validation checklist (live, via `npm run tauri dev`)**
+
+```bash
+npm run tauri dev
+```
+
+With the app open, physically check from normal couch viewing distance on the 60" TV:
+
+- [ ] Channel grid: card text, group name, and now-playing program are legible from the couch
+- [ ] Series cards and episode cards show cover art filling the card (not a small centered logo)
+- [ ] Now-playing bar text and stop button are legible and easy to hit
+- [ ] Series page: header title, season chips, and episode descriptions are legible
+- [ ] Settings: all four tabs are legible and controls are easy to read/click
+- [ ] Both light and dark theme (toggle in Settings → General) still render coherently — this redesign is not a dark-only change, both themes consume the same tokens
+
+- [ ] **Step 5: Report back to the user for approval**
+
+Do not build the Tauri binary or touch the production install (`/opt/better-iptv-bin/usr/bin/better-ip-tv`) yet. Per the spec's cutover plan, that only happens after the user explicitly approves the look from Step 4. Stop here and hand control back for review.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** dark/Netflix-style theme → Task 2 tokens; fluid adaptive typography → Task 2 `fontSize` + applied in every component task; larger cover-forward cards → Tasks 3 and 7; all listed components (ChannelCard, MainScreen, CategoryBar, ContentTypeTabs, SeriesView, Settings + tabs, NowPlayingBar) → Tasks 3–10; git worktree isolation → Task 1; no backend/hook-logic changes → enforced throughout, with the one declared exception (Task 8 constants) matching the spec's intent that presentation and its supporting numeric layout constants move together; validation via live TV check, no new automated tests → Task 11; cutover deferred until user approval → Task 11 Step 5.
+- **Placeholder scan:** every task has concrete before/after code or exact shell commands; no "TBD" or "similar to Task N" shortcuts — Task 10's tab files use a fully-specified substitution table (real, exhaustive mapping) rather than hand-transcribing four repetitive form files.
+- **Type consistency:** no function signatures, prop types, or exported interfaces change anywhere in this plan — `GridConfig`, `ChannelCardProps`, `NowPlayingBarProps`, `SeriesViewProps`, `Tabs`/`TabsList`/`TabsTrigger`/`TabsContent` all keep their existing shapes.

--- a/docs/superpowers/specs/2026-07-30-tv-redesign-design.md
+++ b/docs/superpowers/specs/2026-07-30-tv-redesign-design.md
@@ -1,0 +1,99 @@
+# Redesign visual "10-foot UI" (uso em TV grande)
+
+## Contexto
+
+O usuário usa uma TV Samsung de 60" como monitor principal para o Better IPTV.
+A interface atual (grade de canais, página de série, configurações) foi
+desenhada para tela de desktop comum: fontes pequenas, cards compactos,
+pouco contraste — difícil de ler a distância. Controle é feito com
+mouse/teclado normais (não há necessidade de navegação por D-pad/controle
+remoto), então o problema é puramente de legibilidade/hierarquia visual, não
+de input.
+
+Referência de estilo escolhida pelo usuário: interfaces de streaming
+modernas (Netflix e afins) — tema escuro, cards com imagem de capa em
+destaque, tipografia grande e limpa, bastante espaço em branco.
+
+Este é um redesign visual completo (substitui o visual padrão), não um modo
+alternável. O usuário quer que o trabalho aconteça isolado da versão atual
+(que já está funcionando em produção, ver `docs/superpowers/specs/` — fixes
+de parser Xtream, CSP e SQL aplicados em 2026-07-29/30), com possibilidade de
+abandonar sem qualquer risco à versão em uso.
+
+Fora de escopo (decidido durante o brainstorming): embutir o player MPV
+dentro da janela do app. Motivo: o mecanismo do MPV para renderizar dentro de
+uma janela hospedeira (`--wid`) foi desenhado para X11 e é instável/mal
+suportado em compositores Wayland nativos como o Hyprland (que é o ambiente
+do usuário). O risco/esforço não compensa o ganho percebido, e o usuário
+concordou em manter o MPV como processo externo.
+
+## Arquitetura / isolamento
+
+- Trabalho feito num **git worktree** novo: `~/Projects/better-iptv-tv-redesign`,
+  branch `feature/tv-redesign`, criada a partir de `main` (que já contém os
+  fixes de parser/CSP/SQL do dia 2026-07-29/30).
+- `~/Projects/better-iptv` (checkout original) permanece em `main`, intocado.
+- O binário em produção (`/opt/better-iptv-bin/usr/bin/better-ip-tv`,
+  substituindo o pacote AUR `better-iptv-bin`) **não é tocado** até o usuário
+  aprovar visualmente o resultado e decidir fazer o cutover.
+- Nenhuma mudança de backend Rust é necessária — este redesign é 100%
+  frontend (React/TSX/Tailwind). Os fixes de backend do dia anterior
+  continuam válidos e não são reafetados.
+
+## Direção visual — sistema de tokens
+
+Em vez de editar classes Tailwind soltas em cada componente, criar uma
+pequena camada central de tokens de design:
+
+- **Cores**: paleta escura (dark theme), com contraste alto entre texto e
+  fundo, e uma cor de destaque (accent) consistente para estados ativos/hover.
+  Definida em `tailwind.config.ts` (extend do theme) + variáveis CSS em
+  `index.css`.
+- **Tipografia**: escala fluida via `clamp()` (cresce com o tamanho da
+  janela/tela automaticamente — sem precisar de um toggle "modo TV"
+  separado). Isso também beneficia o uso em desktop comum, já que a escala é
+  contínua.
+- **Espaçamento e densidade**: cards maiores, mais espaço entre eles, imagem
+  de capa em destaque (`object-cover` preenchendo o card, em vez do
+  `object-contain` pequeno atual).
+
+## Escopo — componentes afetados
+
+Toque visual (className/estrutura de apresentação) em:
+
+- `ChannelCard.tsx` — cards maiores, capa em destaque, texto maior
+- `MainScreen.tsx`, `CategoryBar.tsx`, `ContentTypeTabs.tsx` — grade e navegação
+- `SeriesView.tsx` — página de série/temporadas/episódios
+- `Settings.tsx` e abas (`GeneralTab`, `PlaybackTab`, `ParentalTab`, `AboutTab`)
+- `NowPlayingBar.tsx`
+
+**Não afetado**: hooks (`useChannelFilter`, `useEpgData`, `useChannelPlayback`
+etc.), stores (`player-store.ts`), lógica de negócio, backend Rust
+(`src-tauri/`), schema/dados do banco. Mesmos dados, mesma lógica — só a
+camada de apresentação muda. Isso limita o raio de risco do redesign.
+
+## Testes
+
+- Testes de vitest existentes (`src/test/`) cobrem hooks/stores/lib, não
+  className/JSX — continuam passando sem modificação, já que a lógica não
+  muda.
+- Validação visual é manual: `npm run dev` no worktree novo, testado ao vivo
+  na TV do usuário durante o desenvolvimento.
+- Sem necessidade de testes automatizados novos para este trabalho (é
+  puramente visual/apresentação, sem lógica nova a proteger).
+
+## Plano de validação e corte (cutover)
+
+1. Desenvolver e iterar no worktree novo usando `npm run dev` (rápido, sem
+   precisar compilar o Tauri a cada mudança).
+2. Usuário revisa ao vivo na TV, ajustes conforme feedback.
+3. Só depois de aprovação visual: build completo do Tauri
+   (`cargo build --release --features tauri/custom-protocol`, mesma receita
+   usada nos fixes anteriores) no worktree novo.
+4. Backup do binário atual já existe (`/opt/better-iptv-bin/usr/bin/better-ip-tv.orig`).
+   Reinstalar o binário novo só troca o executável — reversível a qualquer
+   momento restaurando o `.orig` ou o binário compilado a partir de
+   `~/Projects/better-iptv` (branch `main`, versão atual).
+5. Se o usuário decidir abandonar o redesign a qualquer momento, o worktree
+   pode ser removido sem qualquer efeito sobre `~/Projects/better-iptv` ou o
+   binário em produção.

--- a/src/components/CategoryBar.tsx
+++ b/src/components/CategoryBar.tsx
@@ -15,7 +15,7 @@ export const CategoryBar = memo(function CategoryBar() {
 
   return (
     <div
-      className="scrollbar-hide flex gap-2 overflow-x-auto bg-gray-800/50 px-4 py-3 pb-6"
+      className="scrollbar-hide flex gap-3 overflow-x-auto bg-bg px-6 py-4 pb-8"
       role="tablist"
       aria-label="Channel categories"
     >
@@ -24,10 +24,10 @@ export const CategoryBar = memo(function CategoryBar() {
         onClick={() => setCategoryFilter(null)}
         role="tab"
         aria-selected={categoryFilter === null}
-        className={`shrink-0 rounded-full px-3 py-1.5 text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-gray-900 ${
+        className={`shrink-0 rounded-full px-4 py-2 text-fluid-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 focus:ring-offset-bg ${
           categoryFilter === null
-            ? 'bg-blue-600 text-white'
-            : 'bg-gray-700 text-gray-300 hover:bg-gray-600'
+            ? 'bg-accent text-white'
+            : 'bg-surface-hover text-text-muted hover:bg-surface'
         } `}
       >
         All
@@ -40,10 +40,10 @@ export const CategoryBar = memo(function CategoryBar() {
           onClick={() => setCategoryFilter(category)}
           role="tab"
           aria-selected={categoryFilter === category}
-          className={`shrink-0 whitespace-nowrap rounded-full px-3 py-1.5 text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-gray-900 ${
+          className={`shrink-0 whitespace-nowrap rounded-full px-4 py-2 text-fluid-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 focus:ring-offset-bg ${
             categoryFilter === category
-              ? 'bg-blue-600 text-white'
-              : 'bg-gray-700 text-gray-300 hover:bg-gray-600'
+              ? 'bg-accent text-white'
+              : 'bg-surface-hover text-text-muted hover:bg-surface'
           } `}
         >
           {category}

--- a/src/components/ChannelCard.tsx
+++ b/src/components/ChannelCard.tsx
@@ -62,6 +62,7 @@ export const ChannelCard = memo(function ChannelCard({
               src={channel.logo}
               alt={channel.name}
               loading="lazy"
+              decoding="async"
               className="h-full w-full object-cover"
             />
           </div>

--- a/src/components/ChannelCard.tsx
+++ b/src/components/ChannelCard.tsx
@@ -45,7 +45,6 @@ export const ChannelCard = memo(function ChannelCard({
 
   // Scale text and padding based on card height
   const isLarge = cardHeight > 280;
-  const isSmall = cardHeight < 220;
 
   return (
     <div
@@ -72,7 +71,7 @@ export const ChannelCard = memo(function ChannelCard({
             style={{ height: `${imageHeight}px` }}
           >
             <span
-              className={`font-bold text-white ${isLarge ? 'text-4xl' : isSmall ? 'text-2xl' : 'text-3xl'}`}
+              className={`font-bold text-white ${isLarge ? 'text-fluid-3xl' : 'text-fluid-2xl'}`}
             >
               {channel.name.charAt(0).toUpperCase()}
             </span>
@@ -92,7 +91,7 @@ export const ChannelCard = memo(function ChannelCard({
           }`}
         >
           <Star
-            className={`${isSmall ? 'h-3 w-3' : 'h-4 w-4'} ${
+            className={`h-4 w-4 ${
               channel.is_favorite ? 'fill-white text-white' : 'text-white'
             }`}
           />
@@ -100,7 +99,7 @@ export const ChannelCard = memo(function ChannelCard({
       </div>
 
       {/* Content section */}
-      <div className={`${isLarge ? 'p-6' : isSmall ? 'p-3' : 'p-5'} flex min-h-0 flex-1 flex-col`}>
+      <div className={`${isLarge ? 'p-6' : 'p-5'} flex min-h-0 flex-1 flex-col`}>
         <h3
           className={`truncate font-medium text-text ${isLarge ? 'text-fluid-lg' : 'text-fluid-base'}`}
         >
@@ -125,7 +124,7 @@ export const ChannelCard = memo(function ChannelCard({
         <button
           onClick={() => onPlay(channel)}
           className={`flex w-full items-center justify-center gap-2 rounded-lg font-medium text-fluid-sm transition-colors ${
-            isLarge ? 'mt-4 px-5 py-3' : isSmall ? 'mt-3 px-4 py-2' : 'mt-3 px-5 py-2.5'
+            isLarge ? 'mt-4 px-5 py-3' : 'mt-3 px-5 py-2.5'
           } ${
             isPlaying
               ? 'bg-red-600 text-white hover:bg-red-700'
@@ -136,17 +135,17 @@ export const ChannelCard = memo(function ChannelCard({
         >
           {isPlaying ? (
             <>
-              <Square className={`${isSmall ? 'h-3 w-3' : 'h-4 w-4'}`} />
+              <Square className="h-4 w-4" />
               Stop
             </>
           ) : channel.content_type === 'series' ? (
             <>
-              <Clapperboard className={`${isSmall ? 'h-3 w-3' : 'h-4 w-4'}`} />
+              <Clapperboard className="h-4 w-4" />
               Browse
             </>
           ) : (
             <>
-              <Play className={`${isSmall ? 'h-3 w-3' : 'h-4 w-4'}`} />
+              <Play className="h-4 w-4" />
               Play
             </>
           )}

--- a/src/components/ChannelCard.tsx
+++ b/src/components/ChannelCard.tsx
@@ -49,21 +49,21 @@ export const ChannelCard = memo(function ChannelCard({
 
   return (
     <div
-      className="relative flex flex-col overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm transition-shadow hover:shadow-md dark:border-gray-700 dark:bg-gray-800"
+      className="relative flex flex-col overflow-hidden rounded-xl border border-border bg-surface shadow-sm transition-shadow hover:shadow-lg"
       style={{ height: `${cardHeight}px` }}
     >
       {/* Logo/Image section */}
-      <div className="group relative flex-shrink-0 bg-gray-900">
+      <div className="group relative flex-shrink-0 bg-bg">
         {channel.logo ? (
           <div
-            className="flex w-full items-center justify-center bg-gray-900 p-2"
+            className="flex w-full items-center justify-center bg-bg"
             style={{ height: `${imageHeight}px` }}
           >
             <img
               src={channel.logo}
               alt={channel.name}
               loading="lazy"
-              className="max-h-full max-w-full object-contain"
+              className="h-full w-full object-cover"
             />
           </div>
         ) : (
@@ -100,22 +100,20 @@ export const ChannelCard = memo(function ChannelCard({
       </div>
 
       {/* Content section */}
-      <div className={`${isLarge ? 'p-4' : isSmall ? 'p-2' : 'p-3'} flex min-h-0 flex-1 flex-col`}>
+      <div className={`${isLarge ? 'p-6' : isSmall ? 'p-3' : 'p-5'} flex min-h-0 flex-1 flex-col`}>
         <h3
-          className={`truncate font-medium text-gray-900 dark:text-white ${isLarge ? 'text-base' : 'text-sm'}`}
+          className={`truncate font-medium text-text ${isLarge ? 'text-fluid-lg' : 'text-fluid-base'}`}
         >
           {channel.name}
         </h3>
         {channel.group_name && (
-          <p
-            className={`mt-0.5 truncate text-gray-500 dark:text-gray-400 ${isSmall ? 'text-[10px]' : 'text-xs'}`}
-          >
+          <p className="mt-0.5 truncate text-fluid-sm text-text-muted">
             {channel.group_name}
           </p>
         )}
         {currentProgram && channel.content_type === 'live' && (
           <p
-            className={`mt-0.5 truncate text-blue-600 dark:text-blue-400 ${isSmall ? 'text-[10px]' : 'text-xs'}`}
+            className="mt-0.5 truncate text-fluid-sm text-accent"
             title={currentProgram}
           >
             📺 {currentProgram}
@@ -126,14 +124,14 @@ export const ChannelCard = memo(function ChannelCard({
         {/* Action button */}
         <button
           onClick={() => onPlay(channel)}
-          className={`flex w-full items-center justify-center gap-2 rounded-md font-medium transition-colors ${
-            isLarge ? 'mt-3 px-4 py-2.5' : isSmall ? 'mt-2 px-3 py-1.5 text-sm' : 'mt-2 px-4 py-2'
+          className={`flex w-full items-center justify-center gap-2 rounded-lg font-medium text-fluid-sm transition-colors ${
+            isLarge ? 'mt-4 px-5 py-3' : isSmall ? 'mt-3 px-4 py-2' : 'mt-3 px-5 py-2.5'
           } ${
             isPlaying
               ? 'bg-red-600 text-white hover:bg-red-700'
               : channel.content_type === 'series'
                 ? 'bg-purple-600 text-white hover:bg-purple-700'
-                : 'bg-blue-600 text-white hover:bg-blue-700'
+                : 'bg-accent text-white hover:bg-accent-hover'
           }`}
         >
           {isPlaying ? (

--- a/src/components/ContentTypeTabs.tsx
+++ b/src/components/ContentTypeTabs.tsx
@@ -45,9 +45,9 @@ export const ContentTypeTabs = memo(function ContentTypeTabs({
   onFilterChange,
 }: ContentTypeTabsProps) {
   return (
-    <div className="border-b border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
+    <div className="border-b border-border bg-surface">
       <div className="mx-auto px-6">
-        <div className="flex gap-2 overflow-x-auto" role="tablist" aria-label="Content type filter">
+        <div className="flex gap-3 overflow-x-auto" role="tablist" aria-label="Content type filter">
           {TABS.map((tab) => (
             <button
               key={tab.value}
@@ -55,10 +55,10 @@ export const ContentTypeTabs = memo(function ContentTypeTabs({
               aria-selected={activeFilter === tab.value}
               aria-controls="channel-list"
               onClick={() => onFilterChange(tab.value)}
-              className={`flex items-center gap-2 whitespace-nowrap border-b-2 px-4 py-3 font-medium transition-colors ${
+              className={`flex items-center gap-2 whitespace-nowrap border-b-2 px-5 py-4 text-fluid-base font-medium transition-colors ${
                 activeFilter === tab.value
-                  ? 'border-blue-600 text-blue-600 dark:border-blue-400 dark:text-blue-400'
-                  : 'border-transparent text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-200'
+                  ? 'border-accent text-accent'
+                  : 'border-transparent text-text-muted hover:text-text'
               }`}
             >
               {tab.icon}

--- a/src/components/MainScreen.tsx
+++ b/src/components/MainScreen.tsx
@@ -241,12 +241,12 @@ export default function MainScreen() {
     if (isNaN(seriesId)) {
       logger.error('Failed to parse series ID from URL:', selectedSeries.url);
       return (
-        <div className="flex h-screen items-center justify-center bg-gray-900">
+        <div className="flex h-screen items-center justify-center bg-bg">
           <div className="text-center">
             <p className="mb-4 text-red-400">Failed to load series: Invalid URL format</p>
             <button
               onClick={() => setSelectedSeries(null)}
-              className="rounded-lg bg-blue-600 px-4 py-2 text-white hover:bg-blue-700"
+              className="rounded-lg bg-accent px-5 py-2.5 text-white hover:bg-accent-hover"
             >
               Go Back
             </button>

--- a/src/components/MainScreen.tsx
+++ b/src/components/MainScreen.tsx
@@ -269,21 +269,21 @@ export default function MainScreen() {
   }
 
   return (
-    <div className="flex h-screen flex-col bg-gray-50 dark:bg-gray-900">
+    <div className="flex h-screen flex-col bg-bg">
       {/* Header */}
-      <div className="border-b border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
+      <div className="border-b border-border bg-surface p-6">
         <div className="mx-auto flex items-center justify-between px-2">
-          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Better IPTV</h1>
-          <div className="flex items-center gap-4">
-            <span className="text-sm text-gray-600 dark:text-gray-400">
+          <h1 className="text-fluid-2xl font-bold text-text">Better IPTV</h1>
+          <div className="flex items-center gap-6">
+            <span className="text-fluid-sm text-text-muted">
               {channels.length} channels
             </span>
             <button
               onClick={() => setShowSettings(true)}
-              className="rounded-lg p-2 transition-colors hover:bg-gray-100 dark:hover:bg-gray-700"
+              className="rounded-lg p-3 transition-colors hover:bg-surface-hover"
               title="Settings"
             >
-              <SettingsIcon className="h-5 w-5 text-gray-600 dark:text-gray-400" />
+              <SettingsIcon className="h-6 w-6 text-text-muted" />
             </button>
           </div>
         </div>
@@ -306,10 +306,10 @@ export default function MainScreen() {
         role="tabpanel"
         aria-label="Channel list"
       >
-        <div className="mx-auto p-4">
+        <div className="mx-auto p-6">
           {filteredChannels.length === 0 ? (
             <div className="py-12 text-center">
-              <p className="text-gray-500 dark:text-gray-400">
+              <p className="text-fluid-base text-text-muted">
                 {searchQuery ? 'No channels found' : 'No channels available'}
               </p>
             </div>
@@ -337,7 +337,7 @@ export default function MainScreen() {
                       transform: `translateY(${virtualRow.start}px)`,
                     }}
                   >
-                    <div className={`grid ${getGridClasses(columns)} gap-4`}>
+                    <div className={`grid ${getGridClasses(columns)} gap-6`}>
                       {rowItems.map((channel) => {
                         const isChannelBlocked = blockedMap.get(channel.id!) ?? false;
 

--- a/src/components/MainScreen.tsx
+++ b/src/components/MainScreen.tsx
@@ -156,7 +156,7 @@ export default function MainScreen() {
     count: rowCount,
     getScrollElement: () => parentRef.current,
     estimateSize: () => estimatedRowHeight,
-    overscan: 3, // Render 3 extra rows above/below viewport
+    overscan: 2, // Render 2 extra rows above/below viewport (reduced from 3: cards are physically larger post-redesign, so the same row-count buffer now covers a bigger pixel/image area — most noticeable in 4K fullscreen with 6 columns)
   });
 
   const handlePlayChannel = useCallback(
@@ -335,6 +335,7 @@ export default function MainScreen() {
                       width: '100%',
                       height: `${virtualRow.size}px`,
                       transform: `translateY(${virtualRow.start}px)`,
+                      willChange: 'transform',
                     }}
                   >
                     <div className={`grid ${getGridClasses(columns)} gap-6`}>

--- a/src/components/NowPlayingBar.tsx
+++ b/src/components/NowPlayingBar.tsx
@@ -29,29 +29,29 @@ export const NowPlayingBar = memo(function NowPlayingBar({
   onStop,
 }: NowPlayingBarProps) {
   return (
-    <div className="bg-blue-600 p-4 text-white">
+    <div className="bg-accent p-6 text-white">
       <div className="mx-auto flex items-center justify-between px-2">
         <div className="flex items-center gap-4">
           {channel.logo && (
-            <div className="flex h-12 w-12 items-center justify-center rounded bg-gray-900 p-1">
+            <div className="flex h-16 w-16 items-center justify-center overflow-hidden rounded-lg bg-black/20">
               <img
                 src={channel.logo}
                 alt={channel.name}
-                className="max-h-full max-w-full object-contain"
+                className="h-full w-full object-cover"
                 loading="lazy"
               />
             </div>
           )}
           <div>
-            <p className="font-medium">{channel.name}</p>
-            <p className="text-sm text-blue-100">{channel.group_name || 'Live TV'}</p>
+            <p className="text-fluid-lg font-medium">{channel.name}</p>
+            <p className="text-fluid-sm text-white/80">{channel.group_name || 'Live TV'}</p>
             {currentProgram && (
-              <p className="mt-1 text-sm text-blue-200">
+              <p className="mt-1 text-fluid-sm text-white/90">
                 <span className="font-medium">Now showing:</span> {currentProgram}
               </p>
             )}
             {nextProgram && (
-              <p className="mt-0.5 text-xs text-blue-200">
+              <p className="mt-0.5 text-fluid-xs text-white/70">
                 <span className="font-medium">Next up:</span> {nextProgram}
               </p>
             )}
@@ -59,10 +59,10 @@ export const NowPlayingBar = memo(function NowPlayingBar({
         </div>
         <button
           onClick={onStop}
-          className="rounded-lg bg-white/20 p-2 transition-colors hover:bg-white/30"
+          className="rounded-lg bg-white/20 p-3 transition-colors hover:bg-white/30"
           aria-label="Stop playback"
         >
-          <Square className="h-5 w-5" />
+          <Square className="h-6 w-6" />
         </button>
       </div>
     </div>

--- a/src/components/NowPlayingBar.tsx
+++ b/src/components/NowPlayingBar.tsx
@@ -51,7 +51,7 @@ export const NowPlayingBar = memo(function NowPlayingBar({
               </p>
             )}
             {nextProgram && (
-              <p className="mt-0.5 text-fluid-xs text-white/70">
+              <p className="mt-0.5 text-fluid-xs text-white/90">
                 <span className="font-medium">Next up:</span> {nextProgram}
               </p>
             )}

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -25,17 +25,17 @@ export const SearchBar = memo(
     ref
   ) {
     return (
-      <div className="border-b border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
+      <div className="border-b border-border bg-surface p-4 dark:bg-surface">
         <div className="mx-auto px-2">
           <div className="relative">
-            <Search className="absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 transform text-gray-400" />
+            <Search className="absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 transform text-text-muted" />
             <input
               ref={ref}
               type="text"
               value={value}
               onChange={(e) => onChange(e.target.value)}
               placeholder={placeholder}
-              className="w-full rounded-lg border border-gray-300 py-2 pl-10 pr-4 focus:border-transparent focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+              className="w-full rounded-lg border border-border py-2 pl-10 pr-4 bg-surface text-text focus:border-transparent focus:ring-2 focus:ring-accent dark:bg-surface dark:text-text"
             />
           </div>
         </div>

--- a/src/components/SeriesView.tsx
+++ b/src/components/SeriesView.tsx
@@ -61,11 +61,11 @@ export default function SeriesView({
 
   if (isLoading) {
     return (
-      <div className="flex h-screen flex-col bg-gray-50 dark:bg-gray-900">
+      <div className="flex h-screen flex-col bg-bg">
         <div className="flex flex-1 items-center justify-center">
           <div className="text-center">
-            <div className="mx-auto mb-4 h-16 w-16 animate-spin rounded-full border-4 border-blue-500 border-t-transparent"></div>
-            <p className="font-medium text-gray-700 dark:text-gray-300">Loading series...</p>
+            <div className="mx-auto mb-4 h-16 w-16 animate-spin rounded-full border-4 border-accent border-t-transparent"></div>
+            <p className="text-fluid-base font-medium text-text-muted">Loading series...</p>
           </div>
         </div>
       </div>
@@ -74,15 +74,15 @@ export default function SeriesView({
 
   if (error || !currentSeries) {
     return (
-      <div className="flex h-screen flex-col bg-gray-50 dark:bg-gray-900">
+      <div className="flex h-screen flex-col bg-bg">
         <div className="flex flex-1 items-center justify-center">
           <div className="text-center">
-            <p className="mb-4 font-medium text-red-600 dark:text-red-400">
+            <p className="mb-4 text-fluid-base font-medium text-red-600 dark:text-red-400">
               {error || 'Failed to load series'}
             </p>
             <button
               onClick={onBack}
-              className="rounded-md bg-blue-600 px-4 py-2 text-white hover:bg-blue-700"
+              className="rounded-lg bg-accent px-5 py-2.5 text-white hover:bg-accent-hover"
             >
               Go Back
             </button>
@@ -95,36 +95,36 @@ export default function SeriesView({
   const selectedSeasonEpisodes = selectedSeason ? currentSeries.episodes[selectedSeason] || [] : [];
 
   return (
-    <div className="flex h-screen flex-col bg-gray-50 dark:bg-gray-900">
+    <div className="flex h-screen flex-col bg-bg">
       {/* Header */}
-      <div className="border-b border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
+      <div className="border-b border-border bg-surface p-6">
         <div className="mx-auto max-w-7xl">
           <button
             onClick={onBack}
-            className="mb-4 flex items-center gap-2 text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
+            className="mb-6 flex items-center gap-2 text-fluid-sm text-accent hover:text-accent-hover"
           >
             <ChevronLeft className="h-5 w-5" />
             Back to Series List
           </button>
-          <div className="flex gap-6">
+          <div className="flex gap-8">
             {currentSeries.info.cover && (
               <img
                 src={currentSeries.info.cover}
                 alt={currentSeries.info.name}
-                className="h-48 w-32 rounded-lg object-cover"
+                className="h-72 w-48 rounded-xl object-cover shadow-lg"
               />
             )}
             <div className="flex-1">
-              <h1 className="mb-2 text-3xl font-bold text-gray-900 dark:text-white">
+              <h1 className="mb-3 text-fluid-3xl font-bold text-text">
                 {currentSeries.info.name}
               </h1>
               {currentSeries.info.genre && (
-                <p className="mb-2 text-sm text-gray-600 dark:text-gray-400">
+                <p className="mb-3 text-fluid-sm text-text-muted">
                   {currentSeries.info.genre}
                 </p>
               )}
               {currentSeries.info.plot && (
-                <p className="line-clamp-3 text-gray-700 dark:text-gray-300">
+                <p className="line-clamp-3 text-fluid-base text-text-muted">
                   {currentSeries.info.plot}
                 </p>
               )}
@@ -134,17 +134,17 @@ export default function SeriesView({
       </div>
 
       {/* Season Selector */}
-      <div className="border-b border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
-        <div className="mx-auto max-w-7xl px-4">
-          <div className="flex gap-2 overflow-x-auto py-4">
+      <div className="border-b border-border bg-surface">
+        <div className="mx-auto max-w-7xl px-6">
+          <div className="flex gap-3 overflow-x-auto py-5">
             {currentSeries.seasons.map((season) => (
               <button
                 key={season.id}
                 onClick={() => setSelectedSeason(season.season_number)}
-                className={`whitespace-nowrap rounded-md px-4 py-2 font-medium transition-colors ${
+                className={`whitespace-nowrap rounded-lg px-5 py-2.5 text-fluid-sm font-medium transition-colors ${
                   selectedSeason === season.season_number
-                    ? 'bg-blue-600 text-white'
-                    : 'bg-gray-200 text-gray-900 hover:bg-gray-300 dark:bg-gray-700 dark:text-white dark:hover:bg-gray-600'
+                    ? 'bg-accent text-white'
+                    : 'bg-surface-hover text-text hover:bg-border'
                 }`}
               >
                 {season.name} ({season.episode_count})
@@ -156,15 +156,15 @@ export default function SeriesView({
 
       {/* Episode List */}
       <div className="flex-1 overflow-y-auto">
-        <div className="mx-auto max-w-7xl p-4">
+        <div className="mx-auto max-w-7xl p-6">
           {selectedSeasonEpisodes.length === 0 ? (
             <div className="py-12 text-center">
-              <p className="text-gray-500 dark:text-gray-400">
+              <p className="text-fluid-base text-text-muted">
                 No episodes available for this season
               </p>
             </div>
           ) : (
-            <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+            <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
               {selectedSeasonEpisodes.map((episode, index) => {
                 // Get all episodes from current to end of season (for playlist playback)
                 const remainingEpisodes = selectedSeasonEpisodes
@@ -206,35 +206,35 @@ interface EpisodeCardProps {
 
 function EpisodeCard({ episode, onPlay }: EpisodeCardProps) {
   return (
-    <div className="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm transition-shadow hover:shadow-md dark:border-gray-700 dark:bg-gray-800">
-      <div className="relative bg-gray-900">
+    <div className="overflow-hidden rounded-xl border border-border bg-surface shadow-sm transition-shadow hover:shadow-lg">
+      <div className="relative bg-bg">
         {episode.info.movie_image ? (
           <img
             src={episode.info.movie_image}
             alt={episode.title}
-            className="h-48 w-full object-cover"
+            className="h-56 w-full object-cover"
           />
         ) : (
-          <div className="flex h-48 w-full items-center justify-center bg-gradient-to-br from-blue-500 to-purple-600">
-            <span className="text-4xl font-bold text-white">E{episode.episode_num}</span>
+          <div className="flex h-56 w-full items-center justify-center bg-gradient-to-br from-accent to-purple-600">
+            <span className="text-fluid-2xl font-bold text-white">E{episode.episode_num}</span>
           </div>
         )}
       </div>
-      <div className="p-3">
-        <h3 className="mb-1 line-clamp-2 font-medium text-gray-900 dark:text-white">
+      <div className="p-5">
+        <h3 className="mb-1 line-clamp-2 text-fluid-base font-medium text-text">
           Episode {episode.episode_num}
         </h3>
-        <p className="mb-2 line-clamp-1 text-sm text-gray-700 dark:text-gray-300">
+        <p className="mb-2 line-clamp-1 text-fluid-sm text-text-muted">
           {episode.title}
         </p>
         {episode.info.plot && (
-          <p className="mb-3 line-clamp-2 text-xs text-gray-600 dark:text-gray-400">
+          <p className="mb-3 line-clamp-2 text-fluid-xs text-text-muted">
             {episode.info.plot}
           </p>
         )}
         <button
           onClick={onPlay}
-          className="flex w-full items-center justify-center gap-2 rounded-md bg-blue-600 px-4 py-2 font-medium text-white transition-colors hover:bg-blue-700"
+          className="flex w-full items-center justify-center gap-2 rounded-lg bg-accent px-5 py-2.5 text-fluid-sm font-medium text-white transition-colors hover:bg-accent-hover"
         >
           <Play className="h-4 w-4" />
           Play

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -315,15 +315,15 @@ export default function Settings({ onClose }: SettingsProps) {
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm">
-      <div className="max-h-[90vh] w-full max-w-2xl overflow-y-auto rounded-lg bg-white shadow-xl dark:bg-gray-800">
+      <div className="max-h-[90vh] w-full max-w-2xl overflow-y-auto rounded-lg bg-surface shadow-xl">
         {/* Header */}
-        <div className="flex items-center justify-between border-b border-gray-200 p-6 dark:border-gray-700">
-          <h2 className="text-2xl font-bold text-gray-900 dark:text-white">Settings</h2>
+        <div className="flex items-center justify-between border-b border-border p-6">
+          <h2 className="text-fluid-2xl font-bold text-text">Settings</h2>
           <button
             onClick={onClose}
-            className="rounded-lg p-2 transition-colors hover:bg-gray-100 dark:hover:bg-gray-700"
+            className="rounded-lg p-2 transition-colors hover:bg-surface-hover"
           >
-            <X className="h-5 w-5 text-gray-600 dark:text-gray-400" />
+            <X className="h-5 w-5 text-text-muted" />
           </button>
         </div>
 
@@ -397,17 +397,17 @@ export default function Settings({ onClose }: SettingsProps) {
         </div>
 
         {/* Footer */}
-        <div className="flex items-center justify-end gap-3 border-t border-gray-200 p-6 dark:border-gray-700">
+        <div className="flex items-center justify-end gap-3 border-t border-border p-6">
           <button
             onClick={onClose}
-            className="rounded-lg px-4 py-2 text-gray-700 transition-colors hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700"
+            className="rounded-lg px-4 py-2 text-text-muted transition-colors hover:bg-surface-hover"
           >
             Cancel
           </button>
           <button
             onClick={handleSave}
             disabled={isSaving || isLoading}
-            className="rounded-lg bg-blue-600 px-4 py-2 text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+            className="rounded-lg bg-accent px-4 py-2 text-white transition-colors hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-50"
           >
             {isSaving ? 'Saving...' : 'Save Changes'}
           </button>

--- a/src/components/settings/AboutTab.tsx
+++ b/src/components/settings/AboutTab.tsx
@@ -92,7 +92,7 @@ export default function AboutTab() {
               logger.error('Failed to open GitHub Sponsors URL:', err)
             );
           }}
-          className="inline-flex items-center gap-2 rounded-lg bg-gray-900 px-4 py-2 text-fluid-sm font-semibold text-white transition-colors hover:bg-surface-hover dark:bg-surface-hover dark:hover:bg-surface-hover"
+          className="inline-flex items-center gap-2 rounded-lg bg-gray-900 px-4 py-2 text-fluid-sm font-semibold text-white transition-colors hover:bg-gray-700 dark:bg-surface-hover dark:hover:bg-surface-hover"
         >
           <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 24 24">
             <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" />

--- a/src/components/settings/AboutTab.tsx
+++ b/src/components/settings/AboutTab.tsx
@@ -92,7 +92,7 @@ export default function AboutTab() {
               logger.error('Failed to open GitHub Sponsors URL:', err)
             );
           }}
-          className="inline-flex items-center gap-2 rounded-lg bg-gray-900 px-4 py-2 text-fluid-sm font-semibold text-white transition-colors hover:bg-gray-700 dark:bg-gray-700 dark:hover:bg-gray-600"
+          className="inline-flex items-center gap-2 rounded-lg bg-gray-900 px-4 py-2 text-fluid-sm font-semibold text-white transition-colors hover:bg-surface-hover dark:bg-surface-hover dark:hover:bg-surface-hover"
         >
           <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 24 24">
             <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" />

--- a/src/components/settings/AboutTab.tsx
+++ b/src/components/settings/AboutTab.tsx
@@ -51,21 +51,21 @@ export default function AboutTab() {
       <div className="flex items-center gap-4">
         <img src={logoImage} alt="Better IPTV" className="h-12 w-12 rounded-xl" />
         <div>
-          <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Better IPTV</h3>
+          <h3 className="text-fluid-lg font-semibold text-text">Better IPTV</h3>
           <div className="mt-0.5 flex items-center gap-2">
             {version && (
               <>
-                <span className="text-sm text-gray-500 dark:text-gray-400">v{version}</span>
-                <span className="text-xs text-gray-400 dark:text-gray-500">·</span>
+                <span className="text-fluid-sm text-text-muted">v{version}</span>
+                <span className="text-fluid-xs text-text-muted">·</span>
               </>
             )}
-            <span className="text-xs text-gray-400 dark:text-gray-500">GPL-2.0</span>
+            <span className="text-fluid-xs text-text-muted">GPL-2.0</span>
           </div>
         </div>
       </div>
 
       {/* Support copy */}
-      <p className="text-pretty text-sm leading-relaxed text-gray-600 dark:text-gray-400">
+      <p className="text-pretty text-fluid-sm leading-relaxed text-text-muted">
         Better IPTV is built and maintained by a single developer in their spare time — no ads, no
         subscriptions, no commercial backing. If you find it useful, consider supporting its
         development.
@@ -79,7 +79,7 @@ export default function AboutTab() {
               logger.error('Failed to open Ko-fi URL:', err)
             );
           }}
-          className="inline-flex items-center gap-2 rounded-lg bg-[#FF5E5B] px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-[#e54f4d]"
+          className="inline-flex items-center gap-2 rounded-lg bg-[#FF5E5B] px-4 py-2 text-fluid-sm font-semibold text-white transition-colors hover:bg-[#e54f4d]"
         >
           <svg className="h-4 w-4" viewBox="0 0 24 24" fill="currentColor">
             <path d="M23.881 8.948c-.773-4.085-4.859-4.593-4.859-4.593H.723c-.604 0-.679.798-.679.798s-.082 7.324-.022 11.822c.164 2.424 2.586 2.672 2.586 2.672s8.267-.023 11.966-.049c2.438-.426 2.683-2.566 2.658-3.734 4.352.24 7.422-2.831 6.649-6.916zm-11.062 3.511c-1.246 1.453-4.011 3.976-4.011 3.976s-.121.119-.31.023c-.076-.057-.108-.09-.108-.09-.443-.441-3.368-3.049-4.034-3.954-.709-.965-1.041-2.7-.091-3.71.951-1.01 3.005-1.086 4.363.407 0 0 1.565-1.494 3.468-.947 1.904.547 1.832 2.51.723 4.295zm6.173.478c-.928.116-1.682.028-1.682.028V7.284h1.77s1.971.551 1.971 2.638c0 1.913-.985 2.667-2.059 3.015z" />
@@ -92,7 +92,7 @@ export default function AboutTab() {
               logger.error('Failed to open GitHub Sponsors URL:', err)
             );
           }}
-          className="inline-flex items-center gap-2 rounded-lg bg-gray-900 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-gray-700 dark:bg-gray-700 dark:hover:bg-gray-600"
+          className="inline-flex items-center gap-2 rounded-lg bg-gray-900 px-4 py-2 text-fluid-sm font-semibold text-white transition-colors hover:bg-gray-700 dark:bg-gray-700 dark:hover:bg-gray-600"
         >
           <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 24 24">
             <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" />
@@ -105,7 +105,7 @@ export default function AboutTab() {
               logger.error('Failed to open PayPal URL:', err)
             );
           }}
-          className="inline-flex items-center gap-2 rounded-lg bg-[#003087] px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-[#002070]"
+          className="inline-flex items-center gap-2 rounded-lg bg-[#003087] px-4 py-2 text-fluid-sm font-semibold text-white transition-colors hover:bg-[#002070]"
         >
           <svg className="h-4 w-4" viewBox="0 0 24 24" fill="currentColor">
             <path d="M7.076 21.337H2.47a.641.641 0 0 1-.633-.74L4.944.901C5.026.382 5.474 0 5.998 0h7.46c2.57 0 4.578.543 5.69 1.81 1.01 1.15 1.304 2.42 1.012 4.287-.023.143-.047.288-.077.437-.983 5.05-4.349 6.797-8.647 6.797h-2.19c-.524 0-.968.382-1.05.9l-1.12 7.106zm14.146-14.42a3.35 3.35 0 0 0-.607-.541c-.013.076-.026.175-.041.254-.93 4.778-4.005 7.201-9.138 7.201h-2.19a.563.563 0 0 0-.556.479l-1.187 7.527h-.506l-.24 1.516a.56.56 0 0 0 .554.647h3.882c.46 0 .85-.334.922-.788.06-.26.76-4.852.816-5.09a.932.932 0 0 1 .923-.788h.58c3.76 0 6.705-1.528 7.565-5.946.36-1.847.174-3.388-.777-4.471z" />
@@ -115,12 +115,12 @@ export default function AboutTab() {
       </div>
 
       {/* Crypto accordion */}
-      <div className="overflow-hidden rounded-lg border border-gray-200 dark:border-gray-700">
+      <div className="overflow-hidden rounded-lg border border-border">
         <button
           onClick={() => setCryptoOpen((o) => !o)}
           aria-expanded={cryptoOpen}
           aria-controls="crypto-addresses"
-          className="flex w-full items-center justify-between px-4 py-3 text-sm font-medium text-gray-600 transition-colors hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-200"
+          className="flex w-full items-center justify-between px-4 py-3 text-fluid-sm font-medium text-text-muted transition-colors hover:text-text"
         >
           Donate with crypto
           <svg
@@ -135,21 +135,21 @@ export default function AboutTab() {
         {cryptoOpen && (
           <div
             id="crypto-addresses"
-            className="space-y-3 border-t border-gray-200 px-4 pb-4 pt-3 dark:border-gray-700"
+            className="space-y-3 border-t border-border px-4 pb-4 pt-3"
           >
             {CRYPTO_ADDRESSES.map(({ currency, address }) => (
               <div key={currency}>
-                <p className="mb-1 text-xs font-semibold uppercase text-gray-500 dark:text-gray-400">
+                <p className="mb-1 text-fluid-xs font-semibold uppercase text-text-muted">
                   {currency}
                 </p>
-                <div className="flex items-center gap-2 rounded-lg border border-gray-100 bg-gray-50 px-3 py-2 dark:border-gray-600 dark:bg-gray-700">
-                  <span className="flex-1 font-mono text-xs text-gray-700 dark:text-gray-300">
+                <div className="flex items-center gap-2 rounded-lg border border-border bg-bg px-3 py-2 dark:bg-surface-hover">
+                  <span className="flex-1 font-mono text-fluid-xs text-text-muted">
                     {truncateAddress(address)}
                   </span>
                   <button
                     onClick={() => handleCopy(currency, address)}
                     aria-label={`Copy ${currency} address`}
-                    className="flex-shrink-0 text-gray-400 transition-colors hover:text-blue-600 dark:hover:text-blue-400"
+                    className="flex-shrink-0 text-text-muted transition-colors hover:text-accent"
                   >
                     {copiedCurrency === currency ? (
                       <Check className="h-4 w-4 text-green-500" />
@@ -165,10 +165,10 @@ export default function AboutTab() {
       </div>
 
       {/* Open logs folder */}
-      <div className="border-t border-gray-200 pt-4 dark:border-gray-700">
+      <div className="border-t border-border pt-4">
         <button
           onClick={handleOpenLogs}
-          className="inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-gray-600 transition-colors hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-700"
+          className="inline-flex items-center gap-2 rounded-lg px-3 py-2 text-fluid-sm text-text-muted transition-colors hover:bg-surface-hover"
         >
           <FolderOpen className="h-4 w-4" />
           Open logs folder

--- a/src/components/settings/AboutTab.tsx
+++ b/src/components/settings/AboutTab.tsx
@@ -92,7 +92,7 @@ export default function AboutTab() {
               logger.error('Failed to open GitHub Sponsors URL:', err)
             );
           }}
-          className="inline-flex items-center gap-2 rounded-lg bg-gray-900 px-4 py-2 text-fluid-sm font-semibold text-white transition-colors hover:bg-gray-700 dark:bg-surface-hover dark:hover:bg-surface-hover"
+          className="inline-flex items-center gap-2 rounded-lg bg-gray-900 px-4 py-2 text-fluid-sm font-semibold text-white transition-colors hover:bg-gray-700 dark:bg-surface-hover dark:hover:bg-border"
         >
           <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 24 24">
             <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" />

--- a/src/components/settings/GeneralTab.tsx
+++ b/src/components/settings/GeneralTab.tsx
@@ -92,18 +92,18 @@ export default function GeneralTab({
       {/* Playlist Refresh */}
       {onRefreshPlaylist && playlistName && (
         <section>
-          <h3 className="mb-4 text-lg font-semibold text-gray-900 dark:text-white">Playlist</h3>
-          <div className="rounded-lg border border-gray-200 bg-gray-50 p-4 dark:border-gray-600 dark:bg-gray-700/50">
+          <h3 className="mb-4 text-fluid-lg font-semibold text-text">Playlist</h3>
+          <div className="rounded-lg border border-border bg-bg p-4 dark:bg-surface-hover/50">
             <div className="flex items-center justify-between">
               <div>
-                <p className="font-medium text-gray-900 dark:text-white">{playlistName}</p>
-                <p className="text-sm text-gray-500 dark:text-gray-400">
+                <p className="font-medium text-text">{playlistName}</p>
+                <p className="text-fluid-sm text-text-muted">
                   Refresh to sync with the latest channel list
                 </p>
               </div>
               <button
                 onClick={onRefreshPlaylist}
-                className="flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm text-white transition-colors hover:bg-blue-700"
+                className="flex items-center gap-2 rounded-lg bg-accent px-4 py-2 text-fluid-sm text-white transition-colors hover:bg-accent-hover"
               >
                 <RefreshCw className="h-4 w-4" />
                 Refresh
@@ -115,18 +115,18 @@ export default function GeneralTab({
 
       {/* Playlist Request Settings */}
       <section>
-        <h3 className="mb-4 text-lg font-semibold text-gray-900 dark:text-white">
+        <h3 className="mb-4 text-fluid-lg font-semibold text-text">
           Playlist Requests
         </h3>
         <div className="space-y-4">
           <div>
-            <label className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
+            <label className="mb-2 block text-fluid-sm font-medium text-text-muted">
               User-Agent
             </label>
             <select
               value={playlistUserAgentMode}
               onChange={(e) => onPlaylistUserAgentModeChange(e.target.value as UserAgentMode)}
-              className="w-full rounded-lg border border-gray-300 px-4 py-2 focus:border-transparent focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:[color-scheme:dark]"
+              className="w-full rounded-lg border border-border bg-surface-hover px-4 py-2 text-text focus:border-transparent focus:ring-2 focus:ring-accent dark:[color-scheme:dark]"
             >
               {USER_AGENT_OPTIONS.map((option) => (
                 <option key={option.mode} value={option.mode}>
@@ -134,14 +134,14 @@ export default function GeneralTab({
                 </option>
               ))}
             </select>
-            <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+            <p className="mt-1 text-fluid-xs text-text-muted">
               Used when downloading playlists and Xtream-provided EPG data
             </p>
-            <p className="mt-2 break-all text-xs text-gray-500 dark:text-gray-400">
+            <p className="mt-2 break-all text-fluid-xs text-text-muted">
               Current header: <span className="font-mono">{userAgentPreview.value}</span>
             </p>
             {userAgentPreview.usingFallback && (
-              <p className="mt-1 text-xs text-amber-600 dark:text-amber-400">
+              <p className="mt-1 text-fluid-xs text-amber-600 dark:text-amber-400">
                 Custom value is currently invalid or empty, fallback to default will be used.
               </p>
             )}
@@ -149,7 +149,7 @@ export default function GeneralTab({
 
           {playlistUserAgentMode === 'custom' && (
             <div>
-              <label className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
+              <label className="mb-2 block text-fluid-sm font-medium text-text-muted">
                 Custom User-Agent
               </label>
               <input
@@ -157,7 +157,7 @@ export default function GeneralTab({
                 value={playlistUserAgentCustom}
                 onChange={(e) => onPlaylistUserAgentCustomChange(e.target.value)}
                 placeholder="Mozilla/5.0 ..."
-                className="w-full rounded-lg border border-gray-300 px-4 py-2 focus:border-transparent focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+                className="w-full rounded-lg border border-border bg-surface-hover px-4 py-2 text-text focus:border-transparent focus:ring-2 focus:ring-accent"
               />
             </div>
           )}
@@ -166,12 +166,12 @@ export default function GeneralTab({
 
       {/* EPG Settings */}
       <section>
-        <h3 className="mb-4 text-lg font-semibold text-gray-900 dark:text-white">
+        <h3 className="mb-4 text-fluid-lg font-semibold text-text">
           Electronic Program Guide (EPG)
         </h3>
         <div className="space-y-4">
           <div>
-            <label className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
+            <label className="mb-2 block text-fluid-sm font-medium text-text-muted">
               EPG URL (XMLTV format)
             </label>
             <input
@@ -179,15 +179,15 @@ export default function GeneralTab({
               value={epgUrl}
               onChange={(e) => onEpgUrlChange(e.target.value)}
               placeholder="http://example.com/epg.xml"
-              className="w-full rounded-lg border border-gray-300 px-4 py-2 focus:border-transparent focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+              className="w-full rounded-lg border border-border bg-surface-hover px-4 py-2 text-text focus:border-transparent focus:ring-2 focus:ring-accent"
             />
-            <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+            <p className="mt-1 text-fluid-xs text-text-muted">
               If EPG data is not provided with Xtream, we recommend using:{' '}
               <a
                 href="https://iptv-epg.org/"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-blue-600 hover:underline dark:text-blue-400"
+                className="text-accent hover:underline"
               >
                 https://iptv-epg.org/
               </a>
@@ -195,11 +195,11 @@ export default function GeneralTab({
           </div>
 
           {/* EPG Status Card */}
-          <div className="rounded-lg border border-gray-200 bg-gray-50 p-4 dark:border-gray-600 dark:bg-gray-700/50">
+          <div className="rounded-lg border border-border bg-bg p-4 dark:bg-surface-hover/50">
             <div className="mb-3 flex items-center justify-between">
-              <span className="text-sm font-medium text-gray-700 dark:text-gray-300">Status</span>
+              <span className="text-fluid-sm font-medium text-text-muted">Status</span>
               {epgStatus?.has_url && (
-                <span className="text-xs text-gray-500 dark:text-gray-400">
+                <span className="text-fluid-xs text-text-muted">
                   {epgStatus.program_count.toLocaleString()} programs
                 </span>
               )}
@@ -208,11 +208,11 @@ export default function GeneralTab({
             {epgStatus ? (
               <div className="space-y-2">
                 {epgStatus.last_fetched ? (
-                  <p className="text-sm text-gray-600 dark:text-gray-400">
+                  <p className="text-fluid-sm text-text-muted">
                     Last updated: {new Date(epgStatus.last_fetched).toLocaleString()}
                   </p>
                 ) : (
-                  <p className="text-sm text-gray-500 dark:text-gray-400">
+                  <p className="text-fluid-sm text-text-muted">
                     {epgStatus.has_url ? 'Never updated' : 'No EPG URL configured'}
                   </p>
                 )}
@@ -220,14 +220,14 @@ export default function GeneralTab({
                 <button
                   onClick={onForceEpgUpdate}
                   disabled={!epgStatus.has_url || isUpdatingEpg}
-                  className="flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+                  className="flex items-center gap-2 rounded-lg bg-accent px-4 py-2 text-fluid-sm text-white transition-colors hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-50"
                 >
                   <RefreshCw className={`h-4 w-4 ${isUpdatingEpg ? 'animate-spin' : ''}`} />
                   {isUpdatingEpg ? 'Updating...' : 'Update Now'}
                 </button>
               </div>
             ) : (
-              <p className="text-sm text-gray-500 dark:text-gray-400">Loading status...</p>
+              <p className="text-fluid-sm text-text-muted">Loading status...</p>
             )}
           </div>
         </div>
@@ -235,10 +235,10 @@ export default function GeneralTab({
 
       {/* Appearance Settings */}
       <section>
-        <h3 className="mb-4 text-lg font-semibold text-gray-900 dark:text-white">Appearance</h3>
+        <h3 className="mb-4 text-fluid-lg font-semibold text-text">Appearance</h3>
         <div className="space-y-4">
           <div>
-            <label className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
+            <label className="mb-2 block text-fluid-sm font-medium text-text-muted">
               Theme
             </label>
             <div className="grid grid-cols-3 gap-3">
@@ -248,8 +248,8 @@ export default function GeneralTab({
                   onClick={() => onThemeChange(t)}
                   className={`rounded-lg border px-4 py-2 capitalize ${
                     theme === t
-                      ? 'border-blue-600 bg-blue-600 text-white'
-                      : 'border-gray-300 bg-white text-gray-900 dark:border-gray-600 dark:bg-gray-700 dark:text-white'
+                      ? 'border-accent bg-accent text-white'
+                      : 'border-border bg-surface-hover text-text'
                   }`}
                 >
                   {t}
@@ -262,18 +262,18 @@ export default function GeneralTab({
 
       {/* Language Settings */}
       <section>
-        <h3 className="mb-4 text-lg font-semibold text-gray-900 dark:text-white">
+        <h3 className="mb-4 text-fluid-lg font-semibold text-text">
           Language Settings
         </h3>
         <div className="space-y-4">
           <div>
-            <label className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
+            <label className="mb-2 block text-fluid-sm font-medium text-text-muted">
               Default Audio Language
             </label>
             <select
               value={audioLang}
               onChange={(e) => onAudioLangChange(e.target.value as LanguageCode)}
-              className="w-full rounded-lg border border-gray-300 px-4 py-2 focus:border-transparent focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:[color-scheme:dark]"
+              className="w-full rounded-lg border border-border bg-surface-hover px-4 py-2 text-text focus:border-transparent focus:ring-2 focus:ring-accent dark:[color-scheme:dark]"
             >
               {LANGUAGE_OPTIONS.map((lang) => (
                 <option key={lang.code} value={lang.code}>
@@ -281,19 +281,19 @@ export default function GeneralTab({
                 </option>
               ))}
             </select>
-            <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+            <p className="mt-1 text-fluid-xs text-text-muted">
               Preferred audio track language (if available in stream)
             </p>
           </div>
 
           <div>
-            <label className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
+            <label className="mb-2 block text-fluid-sm font-medium text-text-muted">
               Default Subtitles Language
             </label>
             <select
               value={subtitleLang}
               onChange={(e) => onSubtitleLangChange(e.target.value as LanguageCode)}
-              className="w-full rounded-lg border border-gray-300 px-4 py-2 focus:border-transparent focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:[color-scheme:dark]"
+              className="w-full rounded-lg border border-border bg-surface-hover px-4 py-2 text-text focus:border-transparent focus:ring-2 focus:ring-accent dark:[color-scheme:dark]"
             >
               {LANGUAGE_OPTIONS.map((lang) => (
                 <option key={lang.code} value={lang.code}>
@@ -301,7 +301,7 @@ export default function GeneralTab({
                 </option>
               ))}
             </select>
-            <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+            <p className="mt-1 text-fluid-xs text-text-muted">
               Preferred subtitle language (if available in stream)
             </p>
           </div>

--- a/src/components/settings/ParentalTab.tsx
+++ b/src/components/settings/ParentalTab.tsx
@@ -42,17 +42,17 @@ export default function ParentalTab({
   return (
     <div className="space-y-6">
       <section>
-        <h3 className="mb-4 text-lg font-semibold text-gray-900 dark:text-white">
+        <h3 className="mb-4 text-fluid-lg font-semibold text-text">
           Parental Controls
         </h3>
         <div className="space-y-4">
           {/* Enable toggle */}
           <div className="flex items-center justify-between">
             <div>
-              <p className="text-sm font-medium text-gray-700 dark:text-gray-300">
+              <p className="text-fluid-sm font-medium text-text-muted">
                 Enable Parental Controls
               </p>
-              <p className="text-xs text-gray-500 dark:text-gray-400">
+              <p className="text-fluid-xs text-text-muted">
                 Restrict access to channels with PIN protection
               </p>
             </div>
@@ -60,7 +60,7 @@ export default function ParentalTab({
               type="checkbox"
               checked={enabled}
               onChange={(e) => onEnabledChange(e.target.checked)}
-              className="h-4 w-4 rounded text-blue-600 focus:ring-blue-500"
+              className="h-4 w-4 rounded text-accent focus:ring-accent"
             />
           </div>
 
@@ -68,7 +68,7 @@ export default function ParentalTab({
             <>
               {/* PIN Setup */}
               <div>
-                <label className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
+                <label className="mb-2 block text-fluid-sm font-medium text-text-muted">
                   PIN Code
                 </label>
                 {hasPin ? (
@@ -89,12 +89,12 @@ export default function ParentalTab({
                 ) : (
                   <button
                     onClick={onSetPin}
-                    className="rounded-lg bg-blue-600 px-4 py-2 text-white hover:bg-blue-700"
+                    className="rounded-lg bg-accent px-4 py-2 text-white hover:bg-accent-hover"
                   >
                     Set PIN
                   </button>
                 )}
-                <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                <p className="mt-1 text-fluid-xs text-text-muted">
                   {hasPin ? 'PIN is currently set' : 'No PIN set - parental controls inactive'}
                 </p>
               </div>
@@ -103,12 +103,12 @@ export default function ParentalTab({
                 <>
                   {/* Manual Channel Blocking */}
                   <div>
-                    <label className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
+                    <label className="mb-2 block text-fluid-sm font-medium text-text-muted">
                       Blocked Channels
                     </label>
                     <button
                       onClick={onOpenChannelBlocking}
-                      className="flex items-center gap-2 rounded-lg border border-gray-300 px-4 py-2 hover:bg-gray-50 dark:border-gray-600 dark:hover:bg-gray-700"
+                      className="flex items-center gap-2 rounded-lg border border-border px-4 py-2 hover:bg-surface-hover"
                     >
                       <Lock className="h-4 w-4" />
                       <span>Select Channels ({blockedCount} blocked)</span>
@@ -118,10 +118,10 @@ export default function ParentalTab({
                   {/* Auto-detection toggle */}
                   <div className="flex items-center justify-between">
                     <div>
-                      <p className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                      <p className="text-fluid-sm font-medium text-text-muted">
                         Auto-detect 18+ Content
                       </p>
-                      <p className="text-xs text-gray-500 dark:text-gray-400">
+                      <p className="text-fluid-xs text-text-muted">
                         Automatically blocks channels with +18, XXX, Adult in name
                       </p>
                     </div>
@@ -129,25 +129,25 @@ export default function ParentalTab({
                       type="checkbox"
                       checked={autoDetect}
                       onChange={(e) => onAutoDetectChange(e.target.checked)}
-                      className="h-4 w-4 rounded text-blue-600 focus:ring-blue-500"
+                      className="h-4 w-4 rounded text-accent focus:ring-accent"
                     />
                   </div>
 
                   {/* Visibility mode */}
                   <div>
-                    <label className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
+                    <label className="mb-2 block text-fluid-sm font-medium text-text-muted">
                       Visibility Mode
                     </label>
                     <select
                       value={visibility}
                       onChange={(e) => onVisibilityChange(e.target.value as ParentalVisibility)}
-                      className="w-full rounded-lg border border-gray-300 px-4 py-2 focus:border-transparent focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:[color-scheme:dark]"
+                      className="w-full rounded-lg border border-border bg-surface-hover px-4 py-2 text-text focus:border-transparent focus:ring-2 focus:ring-accent dark:[color-scheme:dark]"
                     >
                       <option value="hide">Hide completely</option>
                       <option value="lock">Show with lock icon</option>
                       <option value="blur">Show blurred</option>
                     </select>
-                    <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                    <p className="mt-1 text-fluid-xs text-text-muted">
                       How blocked channels appear in the list
                     </p>
                   </div>

--- a/src/components/settings/ParentalTab.tsx
+++ b/src/components/settings/ParentalTab.tsx
@@ -75,7 +75,7 @@ export default function ParentalTab({
                   <div className="flex gap-2">
                     <button
                       onClick={onChangePin}
-                      className="rounded-lg bg-gray-600 px-4 py-2 text-white hover:bg-gray-700"
+                      className="rounded-lg bg-surface-hover px-4 py-2 text-text hover:bg-border"
                     >
                       Change PIN
                     </button>

--- a/src/components/settings/PlaybackTab.tsx
+++ b/src/components/settings/PlaybackTab.tsx
@@ -10,14 +10,14 @@ export default function PlaybackTab({
   return (
     <div className="space-y-6">
       <section>
-        <h3 className="mb-4 text-lg font-semibold text-gray-900 dark:text-white">Playback</h3>
+        <h3 className="mb-4 text-fluid-lg font-semibold text-text">Playback</h3>
         <div className="space-y-4">
           <div className="flex items-center justify-between">
             <div>
-              <p className="text-sm font-medium text-gray-700 dark:text-gray-300">
+              <p className="text-fluid-sm font-medium text-text-muted">
                 Hardware Acceleration
               </p>
-              <p className="text-xs text-gray-500 dark:text-gray-400">
+              <p className="text-fluid-xs text-text-muted">
                 Use GPU for video decoding (recommended)
               </p>
             </div>
@@ -25,7 +25,7 @@ export default function PlaybackTab({
               type="checkbox"
               checked={hardwareAcceleration}
               onChange={(e) => onHardwareAccelerationChange(e.target.checked)}
-              className="h-4 w-4 rounded text-blue-600 focus:ring-blue-500"
+              className="h-4 w-4 rounded text-accent focus:ring-accent"
             />
           </div>
         </div>

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -12,7 +12,7 @@ const TabsList = React.forwardRef<
   <TabsPrimitive.List
     ref={ref}
     className={cn(
-      'inline-flex h-12 w-full items-center justify-center border-b border-gray-200 text-gray-500 dark:border-gray-700 dark:text-gray-400',
+      'inline-flex h-14 w-full items-center justify-center border-b border-border text-text-muted',
       className
     )}
     {...props}
@@ -27,7 +27,7 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      'inline-flex items-center justify-center whitespace-nowrap border-b-2 border-transparent px-4 py-3 text-sm font-medium text-gray-600 transition-all hover:text-gray-900 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 data-[state=active]:border-blue-600 data-[state=active]:text-blue-600 dark:text-gray-400 dark:hover:text-gray-200 dark:data-[state=active]:border-blue-500 dark:data-[state=active]:text-blue-500',
+      'inline-flex items-center justify-center whitespace-nowrap border-b-2 border-transparent px-5 py-4 text-fluid-sm font-medium text-text-muted transition-all hover:text-text focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 data-[state=active]:border-accent data-[state=active]:text-accent',
       className
     )}
     {...props}

--- a/src/hooks/useResponsiveGrid.ts
+++ b/src/hooks/useResponsiveGrid.ts
@@ -16,15 +16,15 @@ interface BreakpointConfig {
 
 // Breakpoint configuration - easily adjustable
 const BREAKPOINTS: BreakpointConfig[] = [
-  { minWidth: 0, columns: 2, minCardHeight: 200, maxCardHeight: 240 },
-  { minWidth: 640, columns: 3, minCardHeight: 220, maxCardHeight: 260 },
-  { minWidth: 1024, columns: 4, minCardHeight: 240, maxCardHeight: 300 },
-  { minWidth: 1440, columns: 5, minCardHeight: 260, maxCardHeight: 320 },
-  { minWidth: 1920, columns: 6, minCardHeight: 280, maxCardHeight: 360 },
-  { minWidth: 2560, columns: 7, minCardHeight: 300, maxCardHeight: 400 },
+  { minWidth: 0, columns: 2, minCardHeight: 240, maxCardHeight: 300 },
+  { minWidth: 640, columns: 3, minCardHeight: 260, maxCardHeight: 320 },
+  { minWidth: 1024, columns: 4, minCardHeight: 300, maxCardHeight: 380 },
+  { minWidth: 1440, columns: 4, minCardHeight: 340, maxCardHeight: 420 },
+  { minWidth: 1920, columns: 5, minCardHeight: 380, maxCardHeight: 480 },
+  { minWidth: 2560, columns: 6, minCardHeight: 420, maxCardHeight: 540 },
 ];
 
-const GAP = 16; // Tailwind gap-4
+const GAP = 24; // Tailwind gap-6 (Task 6 widened the grid gap to match)
 const HEADER_HEIGHT = 200; // Approximate header + search + tabs height
 const NOW_PLAYING_HEIGHT = 100; // Now playing bar
 const PADDING = 32; // Container padding

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,25 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+:root {
+  --color-bg: 249 250 251;
+  --color-surface: 255 255 255;
+  --color-surface-hover: 243 244 246;
+  --color-text: 17 24 39;
+  --color-text-muted: 75 85 99;
+  --color-border: 229 231 235;
+  --color-accent: 220 38 38;
+  --color-accent-hover: 185 28 28;
+}
+
+.dark {
+  --color-bg: 3 7 18;
+  --color-surface: 17 24 39;
+  --color-surface-hover: 31 41 55;
+  --color-text: 249 250 251;
+  --color-text-muted: 156 163 175;
+  --color-border: 55 65 81;
+  --color-accent: 239 68 68;
+  --color-accent-hover: 248 113 113;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,7 +6,29 @@ export default {
   ],
   darkMode: 'class',
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        bg: 'rgb(var(--color-bg) / <alpha-value>)',
+        surface: 'rgb(var(--color-surface) / <alpha-value>)',
+        'surface-hover': 'rgb(var(--color-surface-hover) / <alpha-value>)',
+        text: 'rgb(var(--color-text) / <alpha-value>)',
+        'text-muted': 'rgb(var(--color-text-muted) / <alpha-value>)',
+        border: 'rgb(var(--color-border) / <alpha-value>)',
+        accent: {
+          DEFAULT: 'rgb(var(--color-accent) / <alpha-value>)',
+          hover: 'rgb(var(--color-accent-hover) / <alpha-value>)',
+        },
+      },
+      fontSize: {
+        'fluid-xs': 'clamp(0.75rem, 0.65rem + 0.3vw, 0.9rem)',
+        'fluid-sm': 'clamp(0.875rem, 0.75rem + 0.4vw, 1.125rem)',
+        'fluid-base': 'clamp(1rem, 0.85rem + 0.5vw, 1.375rem)',
+        'fluid-lg': 'clamp(1.125rem, 0.95rem + 0.65vw, 1.625rem)',
+        'fluid-xl': 'clamp(1.375rem, 1.1rem + 1vw, 2rem)',
+        'fluid-2xl': 'clamp(1.75rem, 1.3rem + 1.5vw, 2.75rem)',
+        'fluid-3xl': 'clamp(2.25rem, 1.6rem + 2.25vw, 3.75rem)',
+      },
+    },
   },
   plugins: [],
 }


### PR DESCRIPTION
## Summary
Phase 1 of a TV-friendly UI redesign: introduces a design-token layer (colors, fluid typography) and restyles the core screens/components on top of it — ChannelCard (cover-forward), NowPlayingBar, CategoryBar/ContentTypeTabs, MainScreen header/grid, SeriesView, shared tabs primitive, and Settings shell/tabs. Includes a scroll-jank perf fix for the larger cover-forward cards on 4K fullscreen.

Design spec and implementation plan are included as docs for context on the direction and rationale.

This is scoped to a first batch of screens; a phase 2 PR continues the restyle to the remaining modals/screens on top of this one.

## Test plan
- [ ] `npm run lint`
- [ ] Manual smoke test: browse channels/series, check Settings tabs, verify no layout regressions at common resolutions (1080p, 4K)